### PR TITLE
Get ocean sats command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 BRAIINS_API_KEY=
 MEMPOOL_URL=https://mempool.bitcoinbarcelona.xyz
+OCEAN_ADDRESS=

--- a/hashbidder/domain/btc_address.py
+++ b/hashbidder/domain/btc_address.py
@@ -1,0 +1,173 @@
+"""Bitcoin address primitive with structural and checksum validation.
+
+Bech32/bech32m checksum logic adapted from the BIP173/BIP350 reference
+implementation by Pieter Wuille (MIT license).
+Base58check logic uses stdlib hashlib for the double-SHA256 checksum.
+"""
+
+import hashlib
+import re
+
+# ---------------------------------------------------------------------------
+# Base58check (P2PKH / P2SH)
+# ---------------------------------------------------------------------------
+
+_BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+_BASE58_RE = re.compile(f"^[{_BASE58_ALPHABET}]+$")
+_BASE58_MAP = {c: i for i, c in enumerate(_BASE58_ALPHABET)}
+
+
+def _base58_decode(s: str) -> bytes:
+    """Decode a base58-encoded string to bytes."""
+    n = 0
+    for c in s:
+        n = n * 58 + _BASE58_MAP[c]
+    # Preserve leading zero bytes (encoded as leading '1' chars).
+    leading = len(s) - len(s.lstrip("1"))
+    raw = n.to_bytes(max((n.bit_length() + 7) // 8, 1), "big")
+    return b"\x00" * leading + raw
+
+
+def _validate_base58check(value: str) -> None:
+    """Validate a base58check-encoded address (P2PKH or P2SH)."""
+    if not _BASE58_RE.match(value):
+        raise ValueError(f"Invalid base58 characters in address: {value!r}")
+    if not (25 <= len(value) <= 34):
+        raise ValueError(
+            f"Base58 address must be 25-34 characters, got {len(value)}: {value!r}"
+        )
+    decoded = _base58_decode(value)
+    if len(decoded) != 25:
+        raise ValueError(f"Base58 address decodes to wrong length: {value!r}")
+    payload, checksum = decoded[:-4], decoded[-4:]
+    expected = hashlib.sha256(hashlib.sha256(payload).digest()).digest()[:4]
+    if checksum != expected:
+        raise ValueError(f"Base58check checksum mismatch: {value!r}")
+
+
+# ---------------------------------------------------------------------------
+# Bech32 / bech32m (P2WPKH / P2WSH / P2TR)
+# ---------------------------------------------------------------------------
+
+_BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+_BECH32_MAP = {c: i for i, c in enumerate(_BECH32_CHARSET)}
+_BECH32_RE = re.compile(r"^bc1[ac-hj-np-z02-9]+$")
+
+_BECH32_CONST = 1
+_BECH32M_CONST = 0x2BC830A3
+
+
+def _bech32_polymod(values: list[int]) -> int:
+    """Compute the bech32 checksum polynomial."""
+    generator = [0x3B6A57B2, 0x26508E6D, 0x1EA119FA, 0x3D4233DD, 0x2A1462B3]
+    chk = 1
+    for value in values:
+        top = chk >> 25
+        chk = (chk & 0x1FFFFFF) << 5 ^ value
+        for i in range(5):
+            chk ^= generator[i] if ((top >> i) & 1) else 0
+    return chk
+
+
+def _bech32_hrp_expand(hrp: str) -> list[int]:
+    """Expand the human-readable part for checksum computation."""
+    return [ord(x) >> 5 for x in hrp] + [0] + [ord(x) & 31 for x in hrp]
+
+
+def _validate_bech32(value: str) -> None:
+    """Validate a bech32/bech32m-encoded address."""
+    lower = value.lower()
+    if lower != value:
+        raise ValueError(f"Bech32 address must be lowercase: {value!r}")
+    if not _BECH32_RE.match(lower):
+        raise ValueError(f"Invalid bech32 characters in address: {value!r}")
+    # bc1q (P2WPKH) = 42, bc1q (P2WSH) = 62, bc1p (taproot) = 62.
+    if len(value) not in (42, 62):
+        raise ValueError(
+            f"Bech32 address must be 42 or 62 characters, got {len(value)}: {value!r}"
+        )
+    # Decode the data part and verify the checksum.
+    data_part = lower[3:]  # after "bc1"
+    data = [_BECH32_MAP[c] for c in data_part]
+    const = _bech32_polymod(_bech32_hrp_expand("bc") + data)
+    # Witness version 0 uses bech32, versions 1+ use bech32m.
+    witness_version = data[0]
+    if witness_version == 0:
+        expected = _BECH32_CONST
+    else:
+        expected = _BECH32M_CONST
+    if const != expected:
+        raise ValueError(f"Bech32 checksum mismatch: {value!r}")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def _validate(value: str) -> None:
+    """Validate structural properties and checksum of a Bitcoin address.
+
+    Raises:
+        ValueError: If the address fails validation.
+    """
+    if not value:
+        raise ValueError("BTC address must not be empty")
+
+    if value.lower().startswith("bc1"):
+        _validate_bech32(value)
+        return
+
+    if value.startswith(("1", "3")):
+        _validate_base58check(value)
+        return
+
+    raise ValueError(
+        f"Unrecognized address format (expected prefix 1, 3, or bc1): {value!r}"
+    )
+
+
+class BtcAddress:
+    """A validated Bitcoin mainnet address.
+
+    Validates prefix, character set, length, and checksum for P2PKH (1...),
+    P2SH (3...), bech32 (bc1q...), and bech32m (bc1p...) addresses.
+    """
+
+    def __init__(self, value: str) -> None:
+        """Create a BTC address, raising ValueError if invalid.
+
+        Args:
+            value: The raw address string.
+
+        Raises:
+            ValueError: If the address fails validation.
+        """
+        stripped = value.strip()
+        _validate(stripped)
+        self._value = stripped
+
+    @property
+    def value(self) -> str:
+        """The raw address string."""
+        return self._value
+
+    def truncated(self) -> str:
+        """Shortened form for display: first 7 + '...' + last 4 chars."""
+        if len(self._value) <= 14:
+            return self._value
+        return f"{self._value[:7]}...{self._value[-4:]}"
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, BtcAddress):
+            return self._value == other._value
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._value)
+
+    def __repr__(self) -> str:
+        return f"BtcAddress({self._value!r})"
+
+    def __str__(self) -> str:
+        return self._value

--- a/hashbidder/domain/btc_address.py
+++ b/hashbidder/domain/btc_address.py
@@ -1,16 +1,12 @@
 """Bitcoin address primitive with structural and checksum validation.
 
 Bech32/bech32m checksum logic adapted from the BIP173/BIP350 reference
-implementation by Pieter Wuille (MIT license).
+implementation (MIT license).
 Base58check logic uses stdlib hashlib for the double-SHA256 checksum.
 """
 
 import hashlib
 import re
-
-# ---------------------------------------------------------------------------
-# Base58check (P2PKH / P2SH)
-# ---------------------------------------------------------------------------
 
 _BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 _BASE58_RE = re.compile(f"^[{_BASE58_ALPHABET}]+$")
@@ -44,10 +40,6 @@ def _validate_base58check(value: str) -> None:
     if checksum != expected:
         raise ValueError(f"Base58check checksum mismatch: {value!r}")
 
-
-# ---------------------------------------------------------------------------
-# Bech32 / bech32m (P2WPKH / P2WSH / P2TR)
-# ---------------------------------------------------------------------------
 
 _BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
 _BECH32_MAP = {c: i for i, c in enumerate(_BECH32_CHARSET)}
@@ -98,11 +90,6 @@ def _validate_bech32(value: str) -> None:
         expected = _BECH32M_CONST
     if const != expected:
         raise ValueError(f"Bech32 checksum mismatch: {value!r}")
-
-
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
 
 
 def _validate(value: str) -> None:

--- a/hashbidder/domain/hashrate.py
+++ b/hashbidder/domain/hashrate.py
@@ -53,6 +53,7 @@ for _u in HashUnit:
     _title = _u.name.capitalize() + "/s"  # e.g. "Th/s", "Gh/s", "H/s"
     _RATE_STR_MAP[_canonical] = _u
     _RATE_STR_MAP[_title] = _u
+del _u, _canonical, _title
 
 _UNITS_ASC = sorted(HashUnit, key=lambda u: u.value)
 

--- a/hashbidder/domain/hashrate.py
+++ b/hashbidder/domain/hashrate.py
@@ -74,6 +74,20 @@ class Hashrate:
             time_unit=time_unit,
         )
 
+    def display_unit(self) -> Hashrate:
+        """Convert to the largest unit where 1 <= int(value) < 1000.
+
+        For zero hashrate, returns in the smallest unit (H).
+        """
+        units = sorted(HashUnit, key=lambda u: u.value)
+        best = self.to(units[0], self.time_unit)
+        for unit in units:
+            converted = self.to(unit, self.time_unit)
+            int_part = int(converted.value)
+            if 1 <= int_part < 1000:
+                best = converted
+        return best
+
     def __str__(self) -> str:
         unit = f"{self.hash_unit.name}/{self.time_unit.name.capitalize()}"
         return f"{self.value.normalize()} {unit}"

--- a/hashbidder/domain/hashrate.py
+++ b/hashbidder/domain/hashrate.py
@@ -54,6 +54,8 @@ for _u in HashUnit:
     _RATE_STR_MAP[_canonical] = _u
     _RATE_STR_MAP[_title] = _u
 
+_UNITS_ASC = sorted(HashUnit, key=lambda u: u.value)
+
 
 @dataclass(frozen=True)
 class Hashrate:
@@ -100,9 +102,8 @@ class Hashrate:
 
         For zero hashrate, returns in the smallest unit (H).
         """
-        units = sorted(HashUnit, key=lambda u: u.value)
-        best = self.to(units[0], self.time_unit)
-        for unit in units:
+        best = self.to(_UNITS_ASC[0], self.time_unit)
+        for unit in _UNITS_ASC:
             converted = self.to(unit, self.time_unit)
             int_part = int(converted.value)
             if 1 <= int_part < 1000:

--- a/hashbidder/domain/hashrate.py
+++ b/hashbidder/domain/hashrate.py
@@ -33,6 +33,27 @@ class HashUnit(Enum):
     PH = 1_000_000_000_000_000
     EH = 1_000_000_000_000_000_000
 
+    @classmethod
+    def from_rate_str(cls, s: str) -> HashUnit:
+        """Parse a per-second rate suffix like 'Th/s' or 'GH/s' into a HashUnit.
+
+        Raises:
+            ValueError: If the string is not a recognized rate suffix.
+        """
+        match = _RATE_STR_MAP.get(s)
+        if match is None:
+            raise ValueError(f"unrecognized hashrate unit: {s!r}")
+        return match
+
+
+# Lookup for rate strings: canonical ("TH/s") and title-case ("Th/s") variants.
+_RATE_STR_MAP: dict[str, HashUnit] = {}
+for _u in HashUnit:
+    _canonical = f"{_u.name}/s"  # e.g. "TH/s", "GH/s", "H/s"
+    _title = _u.name.capitalize() + "/s"  # e.g. "Th/s", "Gh/s", "H/s"
+    _RATE_STR_MAP[_canonical] = _u
+    _RATE_STR_MAP[_title] = _u
+
 
 @dataclass(frozen=True)
 class Hashrate:

--- a/hashbidder/formatting.py
+++ b/hashbidder/formatting.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from decimal import Decimal
 
 from hashbidder.client import UserBid
+from hashbidder.domain.btc_address import BtcAddress
 from hashbidder.domain.hashrate import HashratePrice, HashUnit
 from hashbidder.domain.sats import Sats
 from hashbidder.domain.time_unit import TimeUnit
 from hashbidder.hashvalue import HashvalueComponents
+from hashbidder.ocean_client import AccountStats
 from hashbidder.reconcile import (
     CancelAction,
     CancelReason,
@@ -247,6 +249,26 @@ def format_current_bids(bids: tuple[UserBid, ...]) -> str:
             f"amount={bid.amount_sat} sat  "
             f"{bid.status.name}"
         )
+    return "\n".join(lines)
+
+
+def format_ocean_stats(stats: AccountStats, address: BtcAddress) -> str:
+    """Format Ocean account stats for display.
+
+    If all hashrate values are zero, returns an informative message
+    instead of the stats table.
+    """
+    all_zero = all(w.hashrate.value == 0 for w in stats.windows)
+    if all_zero:
+        return f"No stats found for {address} on Ocean."
+
+    lines = [f"Ocean stats for {address.truncated()}", ""]
+    for w in stats.windows:
+        display = w.hashrate.display_unit()
+        label = w.window.value
+        value_str = f"{display.value:.2f} {display.hash_unit.name}/s"
+        lines.append(f"  {label:>6s}    {value_str}")
+
     return "\n".join(lines)
 
 

--- a/hashbidder/main.py
+++ b/hashbidder/main.py
@@ -15,12 +15,14 @@ from dotenv import load_dotenv
 from hashbidder import use_cases
 from hashbidder.client import API_BASE, ApiError, BraiinsClient, HashpowerClient
 from hashbidder.config import load_config
+from hashbidder.domain.btc_address import BtcAddress
 from hashbidder.domain.hashrate import HashUnit
 from hashbidder.domain.time_unit import TimeUnit
 from hashbidder.formatting import (
     format_current_bids,
     format_hashvalue,
     format_hashvalue_verbose,
+    format_ocean_stats,
     format_outcome,
     format_plan,
     format_results_summary,
@@ -31,6 +33,7 @@ from hashbidder.mempool_client import (
     MempoolError,
     MempoolSource,
 )
+from hashbidder.ocean_client import OceanClient, OceanError, OceanSource
 
 
 @dataclass
@@ -39,6 +42,7 @@ class Clients:
 
     braiins: HashpowerClient | None = field(default=None)
     mempool: MempoolSource | None = field(default=None)
+    ocean: OceanSource | None = field(default=None)
 
 
 LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
@@ -72,6 +76,19 @@ def _mempool_errors() -> Iterator[None]:
         yield
     except MempoolError as e:
         raise click.ClickException(f"Mempool error: {e.message}") from e
+    except httpx.TimeoutException:
+        raise click.ClickException("Request timed out.")
+    except httpx.RequestError as e:
+        raise click.ClickException(f"Connection error: {e}") from e
+
+
+@contextlib.contextmanager
+def _ocean_errors() -> Iterator[None]:
+    """Translate Ocean/httpx exceptions into ClickExceptions."""
+    try:
+        yield
+    except OceanError as e:
+        raise click.ClickException(f"Ocean error: {e.message}") from e
     except httpx.TimeoutException:
         raise click.ClickException("Request timed out.")
     except httpx.RequestError as e:
@@ -124,6 +141,8 @@ def cli(ctx: click.Context, verbose: bool, log_file: Path | None) -> None:
         env_url = os.environ.get("MEMPOOL_URL")
         mempool_url = httpx.URL(env_url) if env_url else DEFAULT_MEMPOOL_URL
         app.mempool = MempoolClient(mempool_url, httpx.Client(timeout=10.0))
+    if app.ocean is None:
+        app.ocean = OceanClient(httpx.Client(timeout=10.0))
 
 
 @cli.command()
@@ -181,6 +200,28 @@ def hashvalue(ctx: click.Context) -> None:
         click.echo(format_hashvalue_verbose(components, mempool_url))
     else:
         click.echo(format_hashvalue(components))
+
+
+@cli.command("ocean-account-stats")
+@click.pass_context
+def ocean_account_stats(ctx: click.Context) -> None:
+    """Fetch Ocean hashrate stats for a Bitcoin mining address."""
+    app: Clients = ctx.obj
+    assert app.ocean is not None
+    address_str = os.environ.get("OCEAN_ADDRESS")
+    if not address_str:
+        click.echo("Error: OCEAN_ADDRESS environment variable is required.", err=True)
+        ctx.exit(1)
+        return
+    try:
+        address = BtcAddress(address_str)
+    except ValueError as e:
+        click.echo(f"Error: invalid OCEAN_ADDRESS: {e}", err=True)
+        ctx.exit(1)
+        return
+    with _ocean_errors():
+        stats = use_cases.get_ocean_account_stats(app.ocean, address)
+    click.echo(format_ocean_stats(stats, address))
 
 
 @cli.command("set-bids")

--- a/hashbidder/ocean_client.py
+++ b/hashbidder/ocean_client.py
@@ -1,0 +1,134 @@
+"""Ocean.xyz API client for account hashrate stats."""
+
+import re
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from enum import Enum
+from typing import Protocol
+
+import httpx
+
+from hashbidder.domain.hashrate import Hashrate, HashUnit
+from hashbidder.domain.time_unit import TimeUnit
+
+OCEAN_BASE_URL = "https://ocean.xyz"
+
+
+class OceanTimeWindow(Enum):
+    """Hashrate averaging windows returned by Ocean."""
+
+    DAY = "24 hrs"
+    THREE_HOURS = "3 hrs"
+    TEN_MINUTES = "10 min"
+    FIVE_MINUTES = "5 min"
+    SIXTY_SECONDS = "60 sec"
+
+
+_ROW_RE = re.compile(r'<tr\s+class="table-row">(.*?)</tr>', re.DOTALL)
+_CELL_RE = re.compile(r'<td\s+class="table-cell">(.*?)</td>', re.DOTALL)
+
+
+class OceanError(Exception):
+    """An error returned by or when parsing the Ocean API."""
+
+    def __init__(self, status_code: int, message: str) -> None:
+        """Initialize with the HTTP status code and error message."""
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"HTTP {status_code}: {message}")
+
+
+@dataclass(frozen=True)
+class HashrateWindow:
+    """A single hashrate measurement over a time window."""
+
+    window: OceanTimeWindow
+    hashrate: Hashrate
+
+
+@dataclass(frozen=True)
+class AccountStats:
+    """Hashrate stats for an Ocean account across all time windows."""
+
+    windows: tuple[HashrateWindow, ...]
+
+
+class OceanSource(Protocol):
+    """Protocol for Ocean data sources."""
+
+    def get_account_stats(self, address: str) -> AccountStats:
+        """Fetch hashrate stats for the given address."""
+        ...
+
+
+def _parse_hashrate(text: str) -> Hashrate:
+    """Parse a hashrate string like '1885.8 Th/s' into a Hashrate."""
+    parts = text.strip().split(" ")
+    if len(parts) != 2:
+        raise OceanError(200, f"unexpected hashrate format: {text!r}")
+    value_str, unit_str = parts
+    try:
+        value = Decimal(value_str)
+    except InvalidOperation:
+        raise OceanError(200, f"invalid hashrate value: {value_str!r}")
+    try:
+        hash_unit = HashUnit.from_rate_str(unit_str)
+    except ValueError:
+        raise OceanError(200, f"unrecognized hashrate unit: {unit_str!r}")
+    return Hashrate(value=value, hash_unit=hash_unit, time_unit=TimeUnit.SECOND)
+
+
+def _parse_html(html: str) -> AccountStats:
+    """Parse the Ocean hashrate rows HTML fragment into AccountStats."""
+    rows = _ROW_RE.findall(html)
+    if len(rows) != 5:
+        raise OceanError(
+            200,
+            f"expected 5 rows, got {len(rows)}; response schema may have changed",
+        )
+
+    expected_windows = tuple(OceanTimeWindow)
+    windows: list[HashrateWindow] = []
+    for i, row_html in enumerate(rows):
+        cells = [c.strip() for c in _CELL_RE.findall(row_html)]
+        if len(cells) != 3:
+            raise OceanError(
+                200,
+                f"row {i}: expected 3 cells, got {len(cells)}",
+            )
+        label = cells[0]
+        expected = expected_windows[i]
+        if label != expected.value:
+            raise OceanError(
+                200,
+                f"row {i}: expected period {expected.value!r}, got {label!r}",
+            )
+        hashrate = _parse_hashrate(cells[1])
+        windows.append(HashrateWindow(window=expected, hashrate=hashrate))
+
+    return AccountStats(windows=tuple(windows))
+
+
+class OceanClient:
+    """HTTP client for Ocean.xyz hashrate stats."""
+
+    _HASHRATE_ROWS_PATH = "/template/workers/hashrates/rows"
+
+    def __init__(self, http_client: httpx.Client) -> None:
+        """Initialize with an httpx client."""
+        self._http = http_client
+
+    def get_account_stats(self, address: str) -> AccountStats:
+        """Fetch hashrate stats for the given address.
+
+        Raises:
+            OceanError: On HTTP errors or unexpected response schema.
+        """
+        url = f"{OCEAN_BASE_URL}{self._HASHRATE_ROWS_PATH}"
+        resp = self._http.get(url, params={"user": address})
+        if not resp.is_success:
+            raise OceanError(
+                resp.status_code,
+                resp.text or resp.reason_phrase or "Unknown error",
+            )
+        return _parse_html(resp.text)

--- a/hashbidder/ocean_client.py
+++ b/hashbidder/ocean_client.py
@@ -26,7 +26,7 @@ class OceanTimeWindow(Enum):
 
 
 _ROW_RE = re.compile(r'<tr\s+class="table-row">(.*?)</tr>', re.DOTALL)
-_CELL_RE = re.compile(r'<td\s+class="table-cell">(.*?)</td>', re.DOTALL)
+_CELL_RE = re.compile(r'<td\s+class="table-cell"\s*>(.*?)</td>', re.DOTALL)
 
 
 class OceanError(Exception):

--- a/hashbidder/ocean_client.py
+++ b/hashbidder/ocean_client.py
@@ -64,7 +64,7 @@ class OceanSource(Protocol):
 
 def _parse_hashrate(text: str) -> Hashrate:
     """Parse a hashrate string like '1885.8 Th/s' into a Hashrate."""
-    parts = text.strip().split(" ")
+    parts = text.strip().split()
     if len(parts) != 2:
         raise OceanError(200, f"unexpected hashrate format: {text!r}")
     value_str, unit_str = parts

--- a/hashbidder/ocean_client.py
+++ b/hashbidder/ocean_client.py
@@ -70,12 +70,12 @@ def _parse_hashrate(text: str) -> Hashrate:
     value_str, unit_str = parts
     try:
         value = Decimal(value_str)
-    except InvalidOperation:
-        raise OceanError(200, f"invalid hashrate value: {value_str!r}")
+    except InvalidOperation as e:
+        raise OceanError(200, f"invalid hashrate value: {value_str!r}") from e
     try:
         hash_unit = HashUnit.from_rate_str(unit_str)
-    except ValueError:
-        raise OceanError(200, f"unrecognized hashrate unit: {unit_str!r}")
+    except ValueError as e:
+        raise OceanError(200, f"unrecognized hashrate unit: {unit_str!r}") from e
     return Hashrate(value=value, hash_unit=hash_unit, time_unit=TimeUnit.SECOND)
 
 

--- a/hashbidder/ocean_client.py
+++ b/hashbidder/ocean_client.py
@@ -8,6 +8,7 @@ from typing import Protocol
 
 import httpx
 
+from hashbidder.domain.btc_address import BtcAddress
 from hashbidder.domain.hashrate import Hashrate, HashUnit
 from hashbidder.domain.time_unit import TimeUnit
 
@@ -56,7 +57,7 @@ class AccountStats:
 class OceanSource(Protocol):
     """Protocol for Ocean data sources."""
 
-    def get_account_stats(self, address: str) -> AccountStats:
+    def get_account_stats(self, address: BtcAddress) -> AccountStats:
         """Fetch hashrate stats for the given address."""
         ...
 
@@ -118,14 +119,14 @@ class OceanClient:
         """Initialize with an httpx client."""
         self._http = http_client
 
-    def get_account_stats(self, address: str) -> AccountStats:
+    def get_account_stats(self, address: BtcAddress) -> AccountStats:
         """Fetch hashrate stats for the given address.
 
         Raises:
             OceanError: On HTTP errors or unexpected response schema.
         """
         url = f"{OCEAN_BASE_URL}{self._HASHRATE_ROWS_PATH}"
-        resp = self._http.get(url, params={"user": address})
+        resp = self._http.get(url, params={"user": address.value})
         if not resp.is_success:
             raise OceanError(
                 resp.status_code,

--- a/hashbidder/use_cases.py
+++ b/hashbidder/use_cases.py
@@ -16,8 +16,10 @@ from hashbidder.client import (
 )
 from hashbidder.config import SetBidsConfig
 from hashbidder.domain.bitcoin import BLOCKS_PER_EPOCH
+from hashbidder.domain.btc_address import BtcAddress
 from hashbidder.hashvalue import HashvalueComponents, compute_hashvalue
 from hashbidder.mempool_client import MempoolSource
+from hashbidder.ocean_client import AccountStats, OceanSource
 from hashbidder.reconcile import (
     MANAGEABLE_STATUSES,
     CancelAction,
@@ -54,6 +56,19 @@ def get_current_bids(client: HashpowerClient) -> tuple[UserBid, ...]:
         The user's currently active spot bids.
     """
     return client.get_current_bids()
+
+
+def get_ocean_account_stats(ocean: OceanSource, address: BtcAddress) -> AccountStats:
+    """Fetch Ocean account hashrate stats for the given address.
+
+    Args:
+        ocean: The Ocean data source to use.
+        address: The Bitcoin address to query.
+
+    Returns:
+        The account's hashrate stats across all time windows.
+    """
+    return ocean.get_account_stats(address)
 
 
 def get_hashvalue(mempool: MempoolSource) -> HashvalueComponents:

--- a/tests/cli/test_ocean_account_stats.py
+++ b/tests/cli/test_ocean_account_stats.py
@@ -1,0 +1,108 @@
+"""CLI tests for the ocean-account-stats command."""
+
+from decimal import Decimal
+
+from click.testing import CliRunner
+
+from hashbidder.domain.hashrate import Hashrate, HashUnit
+from hashbidder.domain.time_unit import TimeUnit
+from hashbidder.main import Clients, cli
+from hashbidder.ocean_client import (
+    AccountStats,
+    HashrateWindow,
+    OceanError,
+    OceanTimeWindow,
+)
+from tests.conftest import FakeOceanSource
+
+_ADDRESS = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
+
+
+def _make_stats(value: str = "100", unit: HashUnit = HashUnit.TH) -> AccountStats:
+    return AccountStats(
+        windows=tuple(
+            HashrateWindow(
+                window=tw,
+                hashrate=Hashrate(Decimal(value), unit, TimeUnit.SECOND),
+            )
+            for tw in OceanTimeWindow
+        )
+    )
+
+
+class TestOceanAccountStats:
+    """Tests for the ocean-account-stats CLI command."""
+
+    def test_happy_path(self) -> None:
+        """Prints formatted stats for a valid address."""
+        source = FakeOceanSource(account_stats=_make_stats())
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["ocean-account-stats"],
+            obj=Clients(ocean=source),
+            env={"OCEAN_ADDRESS": _ADDRESS},
+        )
+
+        assert result.exit_code == 0
+        assert "Ocean stats for bc1qw50...f3t4" in result.output
+        assert "24 hrs" in result.output
+
+    def test_all_zeros(self) -> None:
+        """All-zero hashrates show 'no stats' message."""
+        source = FakeOceanSource(account_stats=_make_stats("0"))
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["ocean-account-stats"],
+            obj=Clients(ocean=source),
+            env={"OCEAN_ADDRESS": _ADDRESS},
+        )
+
+        assert result.exit_code == 0
+        assert "No stats found" in result.output
+
+    def test_missing_env_var(self) -> None:
+        """Missing OCEAN_ADDRESS results in error exit."""
+        source = FakeOceanSource(account_stats=_make_stats())
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["ocean-account-stats"],
+            obj=Clients(ocean=source),
+            env={"OCEAN_ADDRESS": ""},
+        )
+
+        assert result.exit_code != 0
+        assert "OCEAN_ADDRESS" in result.output
+
+    def test_invalid_address(self) -> None:
+        """Invalid OCEAN_ADDRESS results in error exit."""
+        source = FakeOceanSource(account_stats=_make_stats())
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["ocean-account-stats"],
+            obj=Clients(ocean=source),
+            env={"OCEAN_ADDRESS": "not-a-valid-address"},
+        )
+
+        assert result.exit_code != 0
+        assert "invalid OCEAN_ADDRESS" in result.output
+
+    def test_ocean_error(self) -> None:
+        """OceanError results in non-zero exit code."""
+        source = FakeOceanSource(
+            account_stats=_make_stats(),
+            error=OceanError(503, "service unavailable"),
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["ocean-account-stats"],
+            obj=Clients(ocean=source),
+            env={"OCEAN_ADDRESS": _ADDRESS},
+        )
+
+        assert result.exit_code != 0
+        assert "service unavailable" in result.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from hashbidder.domain.sats import Sats
 from hashbidder.domain.stratum_url import StratumUrl
 from hashbidder.domain.time_unit import TimeUnit
 from hashbidder.mempool_client import ChainStats, MempoolError
+from hashbidder.ocean_client import AccountStats, OceanError
 
 UPSTREAM = Upstream(
     url=StratumUrl("stratum+tcp://pool.example.com:3333"), identity="worker1"
@@ -193,3 +194,26 @@ class FakeMempoolSource:
         if self._error:
             raise self._error
         return self._chain_stats
+
+
+class FakeOceanSource:
+    """In-memory implementation of OceanSource for testing.
+
+    Supports error injection: set `error` to an OceanError and all
+    calls will raise it.
+    """
+
+    def __init__(
+        self,
+        account_stats: AccountStats,
+        error: OceanError | None = None,
+    ) -> None:
+        """Initialize with canned data and optional error."""
+        self._account_stats = account_stats
+        self._error = error
+
+    def get_account_stats(self, address: str) -> AccountStats:
+        """Return canned account stats or raise injected error."""
+        if self._error:
+            raise self._error
+        return self._account_stats

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from hashbidder.client import (
     UserBid,
 )
 from hashbidder.config import BidConfig, SetBidsConfig
+from hashbidder.domain.btc_address import BtcAddress
 from hashbidder.domain.hashrate import Hashrate, HashratePrice, HashUnit
 from hashbidder.domain.progress import Progress
 from hashbidder.domain.sats import Sats
@@ -212,7 +213,7 @@ class FakeOceanSource:
         self._account_stats = account_stats
         self._error = error
 
-    def get_account_stats(self, address: str) -> AccountStats:
+    def get_account_stats(self, address: BtcAddress) -> AccountStats:
         """Return canned account stats or raise injected error."""
         if self._error:
             raise self._error

--- a/tests/unit/test_btc_address.py
+++ b/tests/unit/test_btc_address.py
@@ -1,0 +1,156 @@
+"""Tests for BtcAddress validation."""
+
+import pytest
+
+from hashbidder.domain.btc_address import BtcAddress
+
+
+class TestValidAddresses:
+    """Known-good addresses that must be accepted."""
+
+    def test_p2pkh(self) -> None:
+        """Satoshi's genesis coinbase address (P2PKH, prefix 1)."""
+        addr = BtcAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa")
+        assert addr.value == "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+
+    def test_p2sh(self) -> None:
+        """P2SH address (prefix 3)."""
+        addr = BtcAddress("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy")
+        assert addr.value == "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"
+
+    def test_bech32_p2wpkh(self) -> None:
+        """Native segwit P2WPKH (bc1q, 42 chars)."""
+        addr = BtcAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+        assert addr.value == "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
+
+    def test_bech32_p2wsh(self) -> None:
+        """Native segwit P2WSH (bc1q, 62 chars), from a real block."""
+        addr = BtcAddress(
+            "bc1qwzrryqr3ja8w7hnja2spmkgfdcgvqwp5swz4af4ngsjecfz0w0pqud7k38"
+        )
+        assert len(addr.value) == 62
+
+    def test_bech32m_taproot(self) -> None:
+        """Taproot P2TR (bc1p, 62 chars), from a real block."""
+        addr = BtcAddress(
+            "bc1pgy84xdguk0e6jzaazrn3kfxvtf6mnerxvdq9uyrwejqan48l6u3qdhkz53"
+        )
+        assert addr.value.startswith("bc1p")
+
+    def test_whitespace_stripped(self) -> None:
+        """Leading/trailing whitespace is stripped before validation."""
+        addr = BtcAddress("  1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa  ")
+        assert addr.value == "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+
+
+class TestInvalidAddresses:
+    """Addresses that must be rejected."""
+
+    def test_empty(self) -> None:
+        """Empty string is rejected."""
+        with pytest.raises(ValueError, match="empty"):
+            BtcAddress("")
+
+    def test_whitespace_only(self) -> None:
+        """Whitespace-only string is rejected."""
+        with pytest.raises(ValueError, match="empty"):
+            BtcAddress("   ")
+
+    def test_unrecognized_prefix(self) -> None:
+        """WIF private key format (prefix 5) is not an address."""
+        with pytest.raises(ValueError, match="Unrecognized"):
+            BtcAddress("5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ")
+
+    def test_bech32_uppercase_rejected(self) -> None:
+        """Bech32 must be all lowercase."""
+        with pytest.raises(ValueError, match="lowercase"):
+            BtcAddress("BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4")
+
+    def test_bech32_wrong_length(self) -> None:
+        """Bech32 address with valid charset but wrong length."""
+        with pytest.raises(ValueError, match="42 or 62"):
+            BtcAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7k")
+
+    def test_bech32_invalid_character(self) -> None:
+        """Bech32 charset does not include 'b', 'i', 'o', '1'."""
+        with pytest.raises(ValueError, match="Invalid bech32"):
+            BtcAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3b4")
+
+    def test_base58_invalid_character(self) -> None:
+        """Base58 charset does not include '0', 'O', 'I', 'l'."""
+        with pytest.raises(ValueError, match="Invalid base58"):
+            BtcAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7Divf0a")
+
+    def test_base58_too_short(self) -> None:
+        """Base58 address shorter than 25 chars is rejected."""
+        with pytest.raises(ValueError, match="25-34"):
+            BtcAddress("1A1zP1")
+
+
+class TestChecksumTampering:
+    """Valid addresses with one character changed to break the checksum."""
+
+    def test_p2pkh_last_char_changed(self) -> None:
+        """Change last char of a valid P2PKH address."""
+        with pytest.raises(ValueError, match="checksum"):
+            BtcAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNb")
+
+    def test_p2pkh_middle_char_changed(self) -> None:
+        """Change a middle char of a valid P2PKH address."""
+        # Original: 1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa
+        # Changed 'G' -> 'H' at position 10
+        with pytest.raises(ValueError, match="checksum"):
+            BtcAddress("1A1zP1eP5QHefi2DMPTfTL5SLmv7DivfNa")
+
+    def test_p2sh_checksum_tampered(self) -> None:
+        """Change last char of a valid P2SH address."""
+        with pytest.raises(ValueError, match="checksum"):
+            BtcAddress("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLz")
+
+    def test_bech32_last_char_changed(self) -> None:
+        """Change last char of a valid bech32 address."""
+        # Original: bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4
+        # Changed '4' -> '5'
+        with pytest.raises(ValueError, match="checksum"):
+            BtcAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5")
+
+    def test_bech32_middle_char_changed(self) -> None:
+        """Change a middle char of a valid bech32 address."""
+        # Original: bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4
+        # Changed 'e' -> 'f' at position 10
+        with pytest.raises(ValueError, match="checksum"):
+            BtcAddress("bc1qw508d6qfjxtdg4y5r3zarvary0c5xw7kv8f3t4")
+
+    def test_bech32m_taproot_tampered(self) -> None:
+        """Change a char in a valid taproot address."""
+        # Original: bc1pgy84xdguk0e6jzaazrn3kfxvtf6mnerxvdq9uyrwejqan48l6u3qdhkz53
+        # Changed last '3' -> '4'
+        with pytest.raises(ValueError, match="checksum"):
+            BtcAddress("bc1pgy84xdguk0e6jzaazrn3kfxvtf6mnerxvdq9uyrwejqan48l6u3qdhkz54")
+
+
+class TestTruncated:
+    """Tests for the truncated display format."""
+
+    def test_long_address_truncated(self) -> None:
+        """Bech32 address shows first 7 + ... + last 4."""
+        addr = BtcAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+        assert addr.truncated() == "bc1qw50...f3t4"
+
+    def test_str_returns_full_address(self) -> None:
+        """str() returns the full untruncated address."""
+        addr = BtcAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa")
+        assert str(addr) == "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+
+    def test_equality(self) -> None:
+        """Same address string produces equal BtcAddress objects."""
+        a = BtcAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa")
+        b = BtcAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa")
+        assert a == b
+        assert hash(a) == hash(b)
+
+    def test_inequality(self) -> None:
+        """Different addresses are not equal."""
+        a = BtcAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa")
+        b = BtcAddress("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy")
+        assert a != b

--- a/tests/unit/test_formatting_ocean.py
+++ b/tests/unit/test_formatting_ocean.py
@@ -1,0 +1,69 @@
+"""Tests for Ocean stats formatting."""
+
+from decimal import Decimal
+
+from hashbidder.domain.btc_address import BtcAddress
+from hashbidder.domain.hashrate import Hashrate, HashUnit
+from hashbidder.domain.time_unit import TimeUnit
+from hashbidder.formatting import format_ocean_stats
+from hashbidder.ocean_client import AccountStats, HashrateWindow, OceanTimeWindow
+
+
+def _window(tw: OceanTimeWindow, value: str, unit: HashUnit) -> HashrateWindow:
+    return HashrateWindow(
+        window=tw,
+        hashrate=Hashrate(Decimal(value), unit, TimeUnit.SECOND),
+    )
+
+
+class TestFormatOceanStats:
+    """Tests for format_ocean_stats."""
+
+    def test_normal_output(self) -> None:
+        """Formats multiple windows with auto-selected units."""
+        stats = AccountStats(
+            windows=(
+                _window(OceanTimeWindow.DAY, "1885800", HashUnit.GH),
+                _window(OceanTimeWindow.THREE_HOURS, "1850000", HashUnit.GH),
+                _window(OceanTimeWindow.TEN_MINUTES, "3220", HashUnit.GH),
+                _window(OceanTimeWindow.FIVE_MINUTES, "3020", HashUnit.GH),
+                _window(OceanTimeWindow.SIXTY_SECONDS, "3000", HashUnit.GH),
+            )
+        )
+
+        output = format_ocean_stats(
+            stats,
+            BtcAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"),
+        )
+
+        assert "Ocean stats for bc1qw50...f3t4" in output
+        assert "24 hrs" in output
+        assert "60 sec" in output
+        # 1885800 GH/s -> 1.89 PH/s (display_unit picks PH)
+        assert "PH/s" in output
+
+    def test_all_zeros(self) -> None:
+        """All-zero hashrates produce a 'no stats' message."""
+        stats = AccountStats(
+            windows=tuple(_window(tw, "0", HashUnit.TH) for tw in OceanTimeWindow)
+        )
+
+        output = format_ocean_stats(
+            stats,
+            BtcAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"),
+        )
+
+        assert "No stats found" in output
+        assert "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4" in output
+
+    def test_legacy_address_truncated(self) -> None:
+        """Legacy P2PKH address is truncated in the header."""
+        stats = AccountStats(
+            windows=tuple(_window(tw, "100", HashUnit.TH) for tw in OceanTimeWindow)
+        )
+
+        output = format_ocean_stats(
+            stats, BtcAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa")
+        )
+
+        assert "1A1zP1e...vfNa" in output

--- a/tests/unit/test_hashrate.py
+++ b/tests/unit/test_hashrate.py
@@ -230,6 +230,44 @@ class TestHashrate:
                 assert a < b
 
 
+class TestDisplayUnit:
+    """Tests for Hashrate.display_unit() auto-selection."""
+
+    def test_large_gh_converts_to_ph(self) -> None:
+        """1,885,800 GH/s should display as 1.8858 PH/s."""
+        h = Hashrate(Decimal("1885800"), HashUnit.GH, TimeUnit.SECOND)
+        result = h.display_unit()
+        assert result.hash_unit == HashUnit.PH
+        assert result.value == Decimal("1.8858")
+
+    def test_500_gh_stays_gh(self) -> None:
+        """500 GH/s already has int part in [1, 1000), stays as GH/s."""
+        h = Hashrate(Decimal("500"), HashUnit.GH, TimeUnit.SECOND)
+        result = h.display_unit()
+        assert result.hash_unit == HashUnit.GH
+        assert result.value == Decimal("500")
+
+    def test_zero_hashrate(self) -> None:
+        """Zero hashrate stays at the smallest unit (H)."""
+        h = Hashrate(Decimal("0"), HashUnit.TH, TimeUnit.SECOND)
+        result = h.display_unit()
+        assert result.hash_unit == HashUnit.H
+        assert result.value == Decimal("0")
+
+    def test_already_in_best_unit(self) -> None:
+        """A value already in the right unit stays there."""
+        h = Hashrate(Decimal("42"), HashUnit.TH, TimeUnit.SECOND)
+        result = h.display_unit()
+        assert result.hash_unit == HashUnit.TH
+        assert result.value == Decimal("42")
+
+    def test_preserves_time_unit(self) -> None:
+        """display_unit keeps the original time unit."""
+        h = Hashrate(Decimal("1885800"), HashUnit.GH, TimeUnit.DAY)
+        result = h.display_unit()
+        assert result.time_unit == TimeUnit.DAY
+
+
 class TestHashratePrice:
     """Tests for the HashratePrice domain type."""
 

--- a/tests/unit/test_ocean_client.py
+++ b/tests/unit/test_ocean_client.py
@@ -1,0 +1,114 @@
+"""Tests for OceanClient HTTP parsing and error handling."""
+
+from decimal import Decimal
+
+import httpx
+import pytest
+
+from hashbidder.domain.hashrate import HashUnit
+from hashbidder.domain.time_unit import TimeUnit
+from hashbidder.ocean_client import OceanClient, OceanError, OceanTimeWindow
+
+_VALID_HTML = """\
+<tr class="table-row">
+  <td class="table-cell">24 hrs</td>
+  <td class="table-cell">1885.8 Th/s</td>
+  <td class="table-cell">123 shares</td>
+</tr>
+<tr class="table-row">
+  <td class="table-cell">3 hrs</td>
+  <td class="table-cell">1850.0 Th/s</td>
+  <td class="table-cell">45 shares</td>
+</tr>
+<tr class="table-row">
+  <td class="table-cell">10 min</td>
+  <td class="table-cell">3.22 Th/s</td>
+  <td class="table-cell">5 shares</td>
+</tr>
+<tr class="table-row">
+  <td class="table-cell">5 min</td>
+  <td class="table-cell">3.02 Th/s</td>
+  <td class="table-cell">3 shares</td>
+</tr>
+<tr class="table-row">
+  <td class="table-cell">60 sec</td>
+  <td class="table-cell">3.00 Th/s</td>
+  <td class="table-cell">1 shares</td>
+</tr>
+"""
+
+
+def _make_client(handler: httpx.MockTransport) -> OceanClient:
+    return OceanClient(http_client=httpx.Client(transport=handler))
+
+
+class TestGetAccountStats:
+    """Tests for OceanClient.get_account_stats."""
+
+    def test_happy_path(self) -> None:
+        """Valid HTML fragment is parsed into correct AccountStats."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert "user=" in str(request.url)
+            return httpx.Response(200, text=_VALID_HTML)
+
+        client = _make_client(httpx.MockTransport(handler))
+        stats = client.get_account_stats("bc1qtest")
+
+        assert len(stats.windows) == 5
+        assert stats.windows[0].window == OceanTimeWindow.DAY
+        assert stats.windows[0].hashrate.value == Decimal("1885.8")
+        assert stats.windows[0].hashrate.hash_unit == HashUnit.TH
+        assert stats.windows[0].hashrate.time_unit == TimeUnit.SECOND
+        assert stats.windows[4].window == OceanTimeWindow.SIXTY_SECONDS
+        assert stats.windows[4].hashrate.value == Decimal("3.00")
+
+    def test_wrong_number_of_rows(self) -> None:
+        """Fewer than 5 rows raises OceanError."""
+        html = (
+            '<tr class="table-row">'
+            '<td class="table-cell">24 hrs</td>'
+            '<td class="table-cell">0.00 Th/s</td>'
+            '<td class="table-cell">0</td>'
+            "</tr>"
+        )
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=html)
+
+        client = _make_client(httpx.MockTransport(handler))
+        with pytest.raises(OceanError, match="expected 5 rows"):
+            client.get_account_stats("bc1qtest")
+
+    def test_unexpected_period_label(self) -> None:
+        """Wrong period label raises OceanError."""
+        html = _VALID_HTML.replace("24 hrs", "48 hrs")
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=html)
+
+        client = _make_client(httpx.MockTransport(handler))
+        with pytest.raises(OceanError, match="expected period"):
+            client.get_account_stats("bc1qtest")
+
+    def test_unrecognized_unit(self) -> None:
+        """Unknown hashrate unit raises OceanError."""
+        html = _VALID_HTML.replace("1885.8 Th/s", "1885.8 Xh/s")
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=html)
+
+        client = _make_client(httpx.MockTransport(handler))
+        with pytest.raises(OceanError, match="unrecognized hashrate unit"):
+            client.get_account_stats("bc1qtest")
+
+    def test_http_error(self) -> None:
+        """Non-2xx response raises OceanError with status code."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="internal server error")
+
+        client = _make_client(httpx.MockTransport(handler))
+        with pytest.raises(OceanError) as exc_info:
+            client.get_account_stats("bc1qtest")
+        assert exc_info.value.status_code == 500

--- a/tests/unit/test_ocean_client.py
+++ b/tests/unit/test_ocean_client.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 import httpx
 import pytest
 
+from hashbidder.domain.btc_address import BtcAddress
 from hashbidder.domain.hashrate import HashUnit
 from hashbidder.domain.time_unit import TimeUnit
 from hashbidder.ocean_client import OceanClient, OceanError, OceanTimeWindow
@@ -53,7 +54,9 @@ class TestGetAccountStats:
             return httpx.Response(200, text=_VALID_HTML)
 
         client = _make_client(httpx.MockTransport(handler))
-        stats = client.get_account_stats("bc1qtest")
+        stats = client.get_account_stats(
+            BtcAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+        )
 
         assert len(stats.windows) == 5
         assert stats.windows[0].window == OceanTimeWindow.DAY
@@ -78,7 +81,9 @@ class TestGetAccountStats:
 
         client = _make_client(httpx.MockTransport(handler))
         with pytest.raises(OceanError, match="expected 5 rows"):
-            client.get_account_stats("bc1qtest")
+            client.get_account_stats(
+                BtcAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+            )
 
     def test_unexpected_period_label(self) -> None:
         """Wrong period label raises OceanError."""
@@ -89,7 +94,9 @@ class TestGetAccountStats:
 
         client = _make_client(httpx.MockTransport(handler))
         with pytest.raises(OceanError, match="expected period"):
-            client.get_account_stats("bc1qtest")
+            client.get_account_stats(
+                BtcAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+            )
 
     def test_unrecognized_unit(self) -> None:
         """Unknown hashrate unit raises OceanError."""
@@ -100,7 +107,9 @@ class TestGetAccountStats:
 
         client = _make_client(httpx.MockTransport(handler))
         with pytest.raises(OceanError, match="unrecognized hashrate unit"):
-            client.get_account_stats("bc1qtest")
+            client.get_account_stats(
+                BtcAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+            )
 
     def test_http_error(self) -> None:
         """Non-2xx response raises OceanError with status code."""
@@ -110,5 +119,7 @@ class TestGetAccountStats:
 
         client = _make_client(httpx.MockTransport(handler))
         with pytest.raises(OceanError) as exc_info:
-            client.get_account_stats("bc1qtest")
+            client.get_account_stats(
+                BtcAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+            )
         assert exc_info.value.status_code == 500

--- a/tests/unit/test_ocean_client.py
+++ b/tests/unit/test_ocean_client.py
@@ -111,6 +111,24 @@ class TestGetAccountStats:
                 BtcAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
             )
 
+    def test_messy_whitespace_in_cells(self) -> None:
+        """Extra whitespace and newlines inside cells are handled."""
+        messy = _VALID_HTML.replace(
+            '<td class="table-cell">1885.8 Th/s</td>',
+            '<td class="table-cell">\n  1885.8  Th/s\n</td>',
+        )
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=messy)
+
+        client = _make_client(httpx.MockTransport(handler))
+        stats = client.get_account_stats(
+            BtcAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+        )
+
+        assert stats.windows[0].hashrate.value == Decimal("1885.8")
+        assert stats.windows[0].hashrate.hash_unit == HashUnit.TH
+
     def test_http_error(self) -> None:
         """Non-2xx response raises OceanError with status code."""
 

--- a/tests/unit/test_use_cases_ocean.py
+++ b/tests/unit/test_use_cases_ocean.py
@@ -1,0 +1,57 @@
+"""Tests for the get_ocean_account_stats use case."""
+
+from decimal import Decimal
+
+import pytest
+
+from hashbidder.domain.btc_address import BtcAddress
+from hashbidder.domain.hashrate import Hashrate, HashUnit
+from hashbidder.domain.time_unit import TimeUnit
+from hashbidder.ocean_client import (
+    AccountStats,
+    HashrateWindow,
+    OceanError,
+    OceanTimeWindow,
+)
+from hashbidder.use_cases import get_ocean_account_stats
+from tests.conftest import FakeOceanSource
+
+
+def _make_stats() -> AccountStats:
+    """Build a simple AccountStats for testing."""
+    windows = tuple(
+        HashrateWindow(
+            window=tw,
+            hashrate=Hashrate(Decimal("100"), HashUnit.TH, TimeUnit.SECOND),
+        )
+        for tw in OceanTimeWindow
+    )
+    return AccountStats(windows=windows)
+
+
+class TestGetOceanAccountStats:
+    """Tests for the get_ocean_account_stats use case."""
+
+    def test_happy_path(self) -> None:
+        """Returns account stats from source."""
+        stats = _make_stats()
+        source = FakeOceanSource(account_stats=stats)
+
+        result = get_ocean_account_stats(
+            source, BtcAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+        )
+
+        assert result == stats
+
+    def test_error_propagates(self) -> None:
+        """OceanError from source propagates to caller."""
+        source = FakeOceanSource(
+            account_stats=_make_stats(),
+            error=OceanError(503, "service unavailable"),
+        )
+
+        with pytest.raises(OceanError) as exc_info:
+            get_ocean_account_stats(
+                source, BtcAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+            )
+        assert exc_info.value.status_code == 503


### PR DESCRIPTION
Add `ocean-account-stats` CLI command that fetches hashrate averages from Ocean.xyz for a Bitcoin address across 5 time windows (60s to 24h). Includes strict HTML parsing, BtcAddress domain type with full checksum validation (base58check + bech32/bech32m), and auto-selected display units.