### PR TITLE
refactor use_cases into multiple files

### DIFF
--- a/hashbidder/use_cases/__init__.py
+++ b/hashbidder/use_cases/__init__.py
@@ -1,0 +1,26 @@
+"""Hashbidder use cases."""
+
+from hashbidder.use_cases.hashvalue import get_hashvalue
+from hashbidder.use_cases.ocean import get_ocean_account_stats
+from hashbidder.use_cases.ping import get_current_bids, ping
+from hashbidder.use_cases.set_bids import (
+    ActionOutcome,
+    ActionStatus,
+    ExecutionResult,
+    SetBidsResult,
+    execute_plan,
+    set_bids,
+)
+
+__all__ = [
+    "ActionOutcome",
+    "ActionStatus",
+    "ExecutionResult",
+    "SetBidsResult",
+    "execute_plan",
+    "get_current_bids",
+    "get_hashvalue",
+    "get_ocean_account_stats",
+    "ping",
+    "set_bids",
+]

--- a/hashbidder/use_cases/hashvalue.py
+++ b/hashbidder/use_cases/hashvalue.py
@@ -1,0 +1,22 @@
+"""Hashvalue use case."""
+
+from hashbidder.domain.bitcoin import BLOCKS_PER_EPOCH
+from hashbidder.hashvalue import HashvalueComponents, compute_hashvalue
+from hashbidder.mempool_client import MempoolSource
+
+
+def get_hashvalue(mempool: MempoolSource) -> HashvalueComponents:
+    """Compute the current hashvalue from on-chain data.
+
+    Args:
+        mempool: The mempool data source to use.
+
+    Returns:
+        All intermediate components and the final hashvalue.
+    """
+    stats = mempool.get_chain_stats(BLOCKS_PER_EPOCH)
+    return compute_hashvalue(
+        difficulty=stats.difficulty,
+        tip_height=stats.tip_height,
+        total_fees=stats.total_fee,
+    )

--- a/hashbidder/use_cases/ocean.py
+++ b/hashbidder/use_cases/ocean.py
@@ -1,0 +1,17 @@
+"""Ocean account stats use case."""
+
+from hashbidder.domain.btc_address import BtcAddress
+from hashbidder.ocean_client import AccountStats, OceanSource
+
+
+def get_ocean_account_stats(ocean: OceanSource, address: BtcAddress) -> AccountStats:
+    """Fetch Ocean account hashrate stats for the given address.
+
+    Args:
+        ocean: The Ocean data source to use.
+        address: The Bitcoin address to query.
+
+    Returns:
+        The account's hashrate stats across all time windows.
+    """
+    return ocean.get_account_stats(address)

--- a/hashbidder/use_cases/ping.py
+++ b/hashbidder/use_cases/ping.py
@@ -1,0 +1,27 @@
+"""Ping and current-bids use cases."""
+
+from hashbidder.client import HashpowerClient, OrderBook, UserBid
+
+
+def ping(client: HashpowerClient) -> OrderBook:
+    """Fetch the current order book.
+
+    Args:
+        client: The hashpower market client to use.
+
+    Returns:
+        The current spot order book snapshot.
+    """
+    return client.get_orderbook()
+
+
+def get_current_bids(client: HashpowerClient) -> tuple[UserBid, ...]:
+    """Fetch the authenticated user's active bids.
+
+    Args:
+        client: The hashpower market client to use.
+
+    Returns:
+        The user's currently active spot bids.
+    """
+    return client.get_current_bids()

--- a/hashbidder/use_cases/set_bids.py
+++ b/hashbidder/use_cases/set_bids.py
@@ -1,4 +1,4 @@
-"""Hashbidder use cases."""
+"""Set-bids use case and execution engine."""
 
 import time
 import uuid
@@ -11,15 +11,9 @@ from hashbidder.client import (
     BidId,
     ClOrderId,
     HashpowerClient,
-    OrderBook,
     UserBid,
 )
 from hashbidder.config import SetBidsConfig
-from hashbidder.domain.bitcoin import BLOCKS_PER_EPOCH
-from hashbidder.domain.btc_address import BtcAddress
-from hashbidder.hashvalue import HashvalueComponents, compute_hashvalue
-from hashbidder.mempool_client import MempoolSource
-from hashbidder.ocean_client import AccountStats, OceanSource
 from hashbidder.reconcile import (
     MANAGEABLE_STATUSES,
     CancelAction,
@@ -32,60 +26,6 @@ from hashbidder.reconcile import (
 
 MAX_ATTEMPTS = 3
 RETRY_DELAY_SECONDS = 5.0
-
-
-def ping(client: HashpowerClient) -> OrderBook:
-    """Fetch the current order book.
-
-    Args:
-        client: The hashpower market client to use.
-
-    Returns:
-        The current spot order book snapshot.
-    """
-    return client.get_orderbook()
-
-
-def get_current_bids(client: HashpowerClient) -> tuple[UserBid, ...]:
-    """Fetch the authenticated user's active bids.
-
-    Args:
-        client: The hashpower market client to use.
-
-    Returns:
-        The user's currently active spot bids.
-    """
-    return client.get_current_bids()
-
-
-def get_ocean_account_stats(ocean: OceanSource, address: BtcAddress) -> AccountStats:
-    """Fetch Ocean account hashrate stats for the given address.
-
-    Args:
-        ocean: The Ocean data source to use.
-        address: The Bitcoin address to query.
-
-    Returns:
-        The account's hashrate stats across all time windows.
-    """
-    return ocean.get_account_stats(address)
-
-
-def get_hashvalue(mempool: MempoolSource) -> HashvalueComponents:
-    """Compute the current hashvalue from on-chain data.
-
-    Args:
-        mempool: The mempool data source to use.
-
-    Returns:
-        All intermediate components and the final hashvalue.
-    """
-    stats = mempool.get_chain_stats(BLOCKS_PER_EPOCH)
-    return compute_hashvalue(
-        difficulty=stats.difficulty,
-        tip_height=stats.tip_height,
-        total_fees=stats.total_fee,
-    )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Splits the single file into one file per use case to avoid bloating the namespace with use case specific objects.