### PR TITLE
Check balance

### DIFF
--- a/hashbidder/bid_runner.py
+++ b/hashbidder/bid_runner.py
@@ -19,6 +19,7 @@ from hashbidder.client import (
     UserBid,
 )
 from hashbidder.config import SetBidsConfig
+from hashbidder.domain.balance_check import BalanceCheck, BalanceStatus, check_balance
 from hashbidder.domain.bid_planning import (
     MANAGEABLE_STATUSES,
     CancelAction,
@@ -38,12 +39,14 @@ POST_EXECUTE_REFETCH_DELAY_SECONDS = 3.0
 class SetBidsResult:
     """Result of a set-bids run.
 
-    `execution` is None for a dry run; otherwise it holds the outcomes
-    and the final bid state read back after the engine ran.
+    `execution` is None for a dry run or when the balance check aborted
+    the run; otherwise it holds the outcomes and the final bid state
+    read back after the engine ran.
     """
 
     plan: ReconciliationPlan
     skipped_bids: tuple[UserBid, ...]
+    balance_check: BalanceCheck
     execution: "ExecutionResult | None" = None
 
 
@@ -52,17 +55,27 @@ def reconcile(
 ) -> SetBidsResult:
     """Bring live bids in line with `config`.
 
-    Reads current bids, plans the diff, and (unless `dry_run`) executes the
-    plan against the API. On a dry run, returns the plan with
-    `execution=None`; otherwise bundles the execution outcomes into the result.
+    Reads current bids, plans the diff, checks the account balance, and
+    (unless `dry_run` or the balance is insufficient) executes the plan
+    against the API. An `INSUFFICIENT` balance aborts the run entirely:
+    no cancels, edits, or creates are executed.
     """
     current_bids = client.get_current_bids()
     plan = plan_bid_changes(config, current_bids)
     skipped = tuple(b for b in current_bids if b.status not in MANAGEABLE_STATUSES)
-    if dry_run:
-        return SetBidsResult(plan=plan, skipped_bids=skipped)
+    balance = client.get_account_balance()
+    balance_result = check_balance(plan, balance.available_sat)
+    if dry_run or balance_result.status == BalanceStatus.INSUFFICIENT:
+        return SetBidsResult(
+            plan=plan, skipped_bids=skipped, balance_check=balance_result
+        )
     execution = execute_plan(client, plan)
-    return SetBidsResult(plan=plan, skipped_bids=skipped, execution=execution)
+    return SetBidsResult(
+        plan=plan,
+        skipped_bids=skipped,
+        balance_check=balance_result,
+        execution=execution,
+    )
 
 
 class ActionStatus(Enum):

--- a/hashbidder/client.py
+++ b/hashbidder/client.py
@@ -21,6 +21,7 @@ from hashbidder.domain.user_bid import BidId, BidStatus, UserBid
 
 __all__ = [
     "API_BASE",
+    "AccountBalance",
     "ApiError",
     "AskItem",
     "BidId",
@@ -95,6 +96,15 @@ class MarketSettings:
 
 
 @dataclass(frozen=True)
+class AccountBalance:
+    """The authenticated account's balance."""
+
+    available_sat: Sats
+    blocked_sat: Sats
+    total_sat: Sats
+
+
+@dataclass(frozen=True)
 class CreateBidResult:
     """Result of creating a new bid."""
 
@@ -140,6 +150,10 @@ class HashpowerClient(Protocol):
         """Fetch the current spot market settings."""
         ...
 
+    def get_account_balance(self) -> AccountBalance:
+        """Fetch the authenticated account's balance."""
+        ...
+
 
 def _parse_user_bid(item: dict[str, Any]) -> UserBid:
     bid = item["bid"]
@@ -179,6 +193,7 @@ class BraiinsClient:
     _SPOT_BID_CURRENT_PATH = "/spot/bid/current"
     _SPOT_BID_PATH = "/spot/bid"
     _SPOT_SETTINGS_PATH = "/spot/settings"
+    _ACCOUNT_BALANCE_PATH = "/account/balance"
 
     # API wire units.
     _API_HASH_UNIT = HashUnit.EH
@@ -394,6 +409,36 @@ class BraiinsClient:
                 seconds=int(data["min_bid_speed_limit_decrease_period_s"])
             ),
             price_tick=PriceTick(sats=Sats(int(data["tick_size_sat"]))),
+        )
+
+    def get_account_balance(self) -> AccountBalance:
+        """Fetch the authenticated account's balance.
+
+        Expects the response to contain exactly one account.
+
+        Raises:
+            ValueError: If no API key is configured, or if the response
+                does not contain exactly one account.
+            httpx.TimeoutException: If the request times out.
+            httpx.HTTPStatusError: If the server returns an error status.
+            httpx.RequestError: If a network-level error occurs.
+        """
+        url = f"{self._base_url}{self._ACCOUNT_BALANCE_PATH}"
+        logger.debug("GET %s", url)
+        response = self._http.get(url, headers=self._auth_headers())
+        response.raise_for_status()
+        logger.debug("Response %s (%d bytes)", response.status_code, len(response.text))
+        data: dict[str, Any] = response.json()
+        accounts = data["accounts"]
+        if len(accounts) != 1:
+            raise ValueError(
+                f"expected exactly one account in balance response, got {len(accounts)}"
+            )
+        account = accounts[0]
+        return AccountBalance(
+            available_sat=Sats(int(account["available_balance_sat"])),
+            blocked_sat=Sats(int(account["blocked_balance_sat"])),
+            total_sat=Sats(int(account["total_balance_sat"])),
         )
 
     def cancel_bid(self, order_id: BidId) -> None:

--- a/hashbidder/domain/balance_check.py
+++ b/hashbidder/domain/balance_check.py
@@ -1,0 +1,79 @@
+"""Balance check: can the account fund the creates in a reconciliation plan?"""
+
+from dataclasses import dataclass
+from datetime import timedelta
+from decimal import Decimal
+from enum import Enum
+
+from hashbidder.domain.bid_planning import ReconciliationPlan
+from hashbidder.domain.hashrate import HashUnit
+from hashbidder.domain.sats import Sats
+from hashbidder.domain.sats_burn_rate import SatsBurnRate
+from hashbidder.domain.time_unit import TimeUnit
+
+# Warn when the runway at the planned burn rate drops below this duration.
+LOW_BALANCE_RUNWAY = timedelta(hours=72)
+
+_ONE_DAY = timedelta(days=1)
+
+
+class BalanceStatus(Enum):
+    """Outcome of a balance check."""
+
+    SUFFICIENT = "sufficient"
+    LOW = "low"
+    INSUFFICIENT = "insufficient"
+
+
+@dataclass(frozen=True)
+class BalanceCheck:
+    """Result of checking the account balance against a plan.
+
+    `runway` is `timedelta.max` when the plan has no creates.
+    """
+
+    required_sat: Sats
+    available_sat: Sats
+    burn_rate: SatsBurnRate
+    runway: timedelta
+    status: BalanceStatus
+
+
+def _plan_burn_rate(plan: ReconciliationPlan) -> SatsBurnRate:
+    """Sum the burn rate across all planned creates."""
+    total = SatsBurnRate.zero()
+    for create in plan.creates:
+        speed_eh_per_day = create.config.speed_limit.to(HashUnit.EH, TimeUnit.DAY).value
+        price_sat_per_eh_day = create.config.price.to(HashUnit.EH, TimeUnit.DAY).sats
+        total += SatsBurnRate(
+            amount=speed_eh_per_day * Decimal(price_sat_per_eh_day),
+            period=_ONE_DAY,
+        )
+    return total
+
+
+def check_balance(plan: ReconciliationPlan, available_sat: Sats) -> BalanceCheck:
+    """Compare the account balance to the sats needed to fund plan creates.
+
+    `INSUFFICIENT` if the balance cannot cover the creates' `amount_sat`.
+    `LOW` if covered but the runway at the planned burn rate is under
+    `LOW_BALANCE_RUNWAY`. `SUFFICIENT` otherwise.
+    """
+    required = sum((int(c.amount) for c in plan.creates), start=0)
+    burn_rate = _plan_burn_rate(plan)
+    runway = burn_rate.runway(available_sat)
+
+    if available_sat < required:
+        status = BalanceStatus.INSUFFICIENT
+    elif runway < LOW_BALANCE_RUNWAY:
+        status = BalanceStatus.LOW
+    else:
+        status = BalanceStatus.SUFFICIENT
+
+    return BalanceCheck(
+        required_sat=Sats(required),
+        available_sat=available_sat,
+        burn_rate=burn_rate,
+        runway=runway,
+        status=status,
+    )

--- a/hashbidder/domain/sats_burn_rate.py
+++ b/hashbidder/domain/sats_burn_rate.py
@@ -1,0 +1,56 @@
+"""Rate of satoshi consumption over time."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from decimal import Decimal
+
+from hashbidder.domain.sats import Sats
+
+
+@dataclass(frozen=True)
+class SatsBurnRate:
+    """A non-negative rate of satoshi consumption.
+
+    Stored as an `amount` of sats consumed over a `period`. Equivalent
+    rates can be expressed over different periods via `to`.
+    """
+
+    amount: Decimal
+    period: timedelta
+
+    def __post_init__(self) -> None:
+        if self.amount < 0:
+            raise ValueError(
+                f"SatsBurnRate amount must be non-negative, got {self.amount}"
+            )
+        if self.period.total_seconds() <= 0:
+            raise ValueError(f"SatsBurnRate period must be positive, got {self.period}")
+
+    @classmethod
+    def zero(cls) -> SatsBurnRate:
+        """The zero burn rate."""
+        return cls(Decimal(0), timedelta(days=1))
+
+    def to(self, period: timedelta) -> SatsBurnRate:
+        """Return an equivalent rate expressed over a different period."""
+        scale = Decimal(period.total_seconds()) / Decimal(self.period.total_seconds())
+        return SatsBurnRate(amount=self.amount * scale, period=period)
+
+    def runway(self, available: Sats) -> timedelta:
+        """Time before `available` sats would be exhausted at this rate.
+
+        Returns `timedelta.max` when the rate is zero.
+        """
+        if self.amount == 0:
+            return timedelta.max
+        sats_per_second = self.amount / Decimal(self.period.total_seconds())
+        seconds = Decimal(int(available)) / sats_per_second
+        return timedelta(seconds=float(seconds))
+
+    def __add__(self, other: SatsBurnRate) -> SatsBurnRate:
+        return SatsBurnRate(
+            amount=self.amount + other.to(self.period).amount,
+            period=self.period,
+        )

--- a/hashbidder/formatting.py
+++ b/hashbidder/formatting.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from decimal import Decimal
 
 import httpx
 
 from hashbidder.bid_runner import ActionOutcome, ActionStatus, SetBidsResult
 from hashbidder.client import UserBid
+from hashbidder.domain.balance_check import (
+    LOW_BALANCE_RUNWAY,
+    BalanceCheck,
+    BalanceStatus,
+)
 from hashbidder.domain.bid_planning import (
     CancelAction,
     CancelReason,
@@ -296,18 +302,57 @@ def format_target_inputs(
     return "\n".join(lines)
 
 
+def _fmt_runway(runway: timedelta) -> str:
+    if runway == timedelta.max:
+        return "\u221e"
+    hours = Decimal(runway.total_seconds()) / Decimal(3600)
+    return f"{hours:.1f}h"
+
+
+def format_balance_check(check: BalanceCheck) -> str:
+    """Render the balance check result as a human-readable section."""
+    threshold_hours = int(LOW_BALANCE_RUNWAY.total_seconds() // 3600)
+    burn_rate_per_hour = check.burn_rate.to(timedelta(hours=1)).amount
+    lines = [
+        "=== Account Balance ===",
+        f"  Available:  {int(check.available_sat):,} sat",
+        f"  Required:   {int(check.required_sat):,} sat",
+        f"  Burn rate:  {burn_rate_per_hour:,.0f} sat/hour",
+        f"  Runway:     {_fmt_runway(check.runway)}",
+    ]
+    if check.status == BalanceStatus.INSUFFICIENT:
+        lines.append("  Status:     INSUFFICIENT \u2014 execution aborted")
+    elif check.status == BalanceStatus.LOW:
+        lines.append(f"  Status:     LOW \u2014 runway under {threshold_hours}h")
+    else:
+        lines.append("  Status:     SUFFICIENT")
+    return "\n".join(lines)
+
+
 def format_set_bids_result(result: SetBidsResult) -> str:
-    """Render a complete set-bids run (dry run or executed) as one string."""
+    """Render a complete set-bids run (dry run, aborted, or executed)."""
     plan = result.plan
     has_changes = bool(plan.edits or plan.creates or plan.cancels)
+    balance_section = format_balance_check(result.balance_check)
+
+    if result.balance_check.status == BalanceStatus.INSUFFICIENT:
+        return "\n".join(
+            [
+                balance_section,
+                "",
+                "Execution aborted: insufficient balance to fund planned creates.",
+                "",
+                format_plan(plan, result.skipped_bids),
+            ]
+        )
 
     if result.execution is None:
-        return format_plan(plan, result.skipped_bids)
+        return "\n".join([balance_section, "", format_plan(plan, result.skipped_bids)])
 
     if not has_changes:
-        return "No changes needed."
+        return "\n".join([balance_section, "", "No changes needed."])
 
-    sections = ["=== Executing Changes ==="]
+    sections = [balance_section, "", "=== Executing Changes ==="]
     sections.extend(format_outcome(o) for o in result.execution.outcomes)
     sections.append("")
     sections.append("=== Results ===")

--- a/hashbidder/main.py
+++ b/hashbidder/main.py
@@ -15,6 +15,7 @@ from dotenv import load_dotenv
 from hashbidder import use_cases
 from hashbidder.client import API_BASE, ApiError, BraiinsClient, HashpowerClient
 from hashbidder.config import SetBidsConfig, TargetHashrateConfig, load_config
+from hashbidder.domain.balance_check import BalanceStatus
 from hashbidder.domain.btc_address import BtcAddress
 from hashbidder.domain.hashrate import HashUnit
 from hashbidder.domain.time_unit import TimeUnit
@@ -276,12 +277,19 @@ def set_bids(ctx: click.Context, bid_config: Path, dry_run: bool) -> None:
             click.echo(format_set_bids_target_result_verbose(target_result))
         else:
             click.echo(format_set_bids_target_result(target_result))
+        if (
+            target_result.set_bids_result.balance_check.status
+            == BalanceStatus.INSUFFICIENT
+        ):
+            ctx.exit(1)
         return
 
     assert isinstance(config, SetBidsConfig)
     with _api_errors():
         result = use_cases.set_bids(app.braiins, config, dry_run)
     click.echo(format_set_bids_result(result))
+    if result.balance_check.status == BalanceStatus.INSUFFICIENT:
+        ctx.exit(1)
 
 
 def main() -> None:

--- a/tests/cli/test_set_bids.py
+++ b/tests/cli/test_set_bids.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
-from hashbidder.client import BidItem, OrderBook
+from hashbidder.client import AccountBalance, BidItem, OrderBook
 from hashbidder.domain.hashrate import Hashrate, HashratePrice, HashUnit
 from hashbidder.domain.sats import Sats
 from hashbidder.domain.time_unit import TimeUnit
@@ -170,6 +170,39 @@ def test_without_dry_run_no_changes(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert "No changes needed." in result.output
+
+
+def test_insufficient_balance_aborts_with_nonzero_exit(tmp_path: Path) -> None:
+    """An insufficient balance aborts execution and exits non-zero."""
+    config_file = tmp_path / "bids.toml"
+    config_file.write_text(
+        TOML_HEADER
+        + """\
+[[bids]]
+price_sat_per_ph_day = 500
+speed_limit_ph_s = 5.0
+"""
+    )
+
+    poor_balance = AccountBalance(
+        available_sat=Sats(10),
+        blocked_sat=Sats(0),
+        total_sat=Sats(10),
+    )
+    client = FakeClient(account_balance=poor_balance)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["set-bids", "--bid-config", str(config_file)], obj=Clients(braiins=client)
+    )
+
+    assert result.exit_code == 1
+    assert "INSUFFICIENT" in result.output
+    assert "Execution aborted" in result.output
+    # No mutations were issued.
+    mutations = [
+        c for c in client.calls if c[0] in ("create_bid", "edit_bid", "cancel_bid")
+    ]
+    assert mutations == []
 
 
 def test_execute_happy_path(tmp_path: Path) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,11 +16,13 @@ from hashbidder.client import (
     UserBid,
 )
 from hashbidder.config import BidConfig, SetBidsConfig
+from hashbidder.domain.balance_check import BalanceCheck, BalanceStatus
 from hashbidder.domain.btc_address import BtcAddress
 from hashbidder.domain.hashrate import Hashrate, HashratePrice, HashUnit
 from hashbidder.domain.price_tick import PriceTick
 from hashbidder.domain.progress import Progress
 from hashbidder.domain.sats import Sats
+from hashbidder.domain.sats_burn_rate import SatsBurnRate
 from hashbidder.domain.stratum_url import StratumUrl
 from hashbidder.domain.time_unit import TimeUnit
 from hashbidder.mempool_client import ChainStats, MempoolError
@@ -52,6 +54,14 @@ DEFAULT_ACCOUNT_BALANCE = AccountBalance(
     available_sat=Sats(10_000_000_000),
     blocked_sat=Sats(0),
     total_sat=Sats(10_000_000_000),
+)
+
+SUFFICIENT_BALANCE_CHECK = BalanceCheck(
+    required_sat=Sats(0),
+    available_sat=DEFAULT_ACCOUNT_BALANCE.available_sat,
+    burn_rate=SatsBurnRate.zero(),
+    runway=timedelta.max,
+    status=BalanceStatus.SUFFICIENT,
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 from hashbidder.client import (
+    AccountBalance,
     ApiError,
     BidId,
     BidStatus,
@@ -45,6 +46,12 @@ DEFAULT_MARKET_SETTINGS = MarketSettings(
     min_bid_price_decrease_period=timedelta(seconds=600),
     min_bid_speed_limit_decrease_period=timedelta(seconds=600),
     price_tick=DEFAULT_PRICE_TICK,
+)
+
+DEFAULT_ACCOUNT_BALANCE = AccountBalance(
+    available_sat=Sats(10_000_000_000),
+    blocked_sat=Sats(0),
+    total_sat=Sats(10_000_000_000),
 )
 
 
@@ -108,6 +115,7 @@ class FakeClient:
         current_bids: tuple[UserBid, ...] = (),
         errors: dict[tuple[str, str], list[ApiError]] | None = None,
         market_settings: MarketSettings = DEFAULT_MARKET_SETTINGS,
+        account_balance: AccountBalance = DEFAULT_ACCOUNT_BALANCE,
     ) -> None:
         """Initialize with optional canned data and error injection."""
         self._orderbook = orderbook or OrderBook(bids=(), asks=())
@@ -115,11 +123,16 @@ class FakeClient:
         self._next_id = 1
         self._errors = errors or {}
         self._market_settings = market_settings
+        self._account_balance = account_balance
         self.calls: list[tuple[str, ...]] = []
 
     def get_market_settings(self) -> MarketSettings:
         """Return the canned market settings."""
         return self._market_settings
+
+    def get_account_balance(self) -> AccountBalance:
+        """Return the canned account balance."""
+        return self._account_balance
 
     def _maybe_raise(self, method: str, key: str) -> None:
         errs = self._errors.get((method, key))

--- a/tests/unit/test_balance_check.py
+++ b/tests/unit/test_balance_check.py
@@ -1,0 +1,111 @@
+"""Tests for the balance check domain module."""
+
+from datetime import timedelta
+from decimal import Decimal
+
+from hashbidder.domain.balance_check import (
+    LOW_BALANCE_RUNWAY,
+    BalanceStatus,
+    check_balance,
+)
+from hashbidder.domain.bid_planning import plan_bid_changes
+from hashbidder.domain.sats import Sats
+from tests.conftest import make_bid_config, make_config
+
+# Burn rate for one create at 500 sat/PH/Day and 5 PH/s:
+#   speed in EH/Day  = 5 PH/s * 86400 s/day / 1000 PH/EH = 432 EH/Day
+#   price in sat/EH/Day = 500 * 1000 = 500_000
+#   cost/day = 432 * 500_000 = 216_000_000 sat
+#   cost/hour = 9_000_000 sat
+_BURN_RATE_SAT_PER_HOUR = 9_000_000
+_BURN_RATE_SAT_PER_DAY = _BURN_RATE_SAT_PER_HOUR * 24
+
+
+class TestCheckBalance:
+    """Tests for check_balance."""
+
+    def test_no_creates_is_sufficient(self) -> None:
+        """An empty plan needs no funds and has no burn rate."""
+        plan = plan_bid_changes(make_config(), ())
+
+        result = check_balance(plan, Sats(0))
+
+        assert result.status == BalanceStatus.SUFFICIENT
+        assert result.required_sat == 0
+        assert result.burn_rate.amount == Decimal(0)
+        assert result.runway == timedelta.max
+
+    def test_sufficient_balance_with_long_runway(self) -> None:
+        """Funds cover creates and runway comfortably exceeds the threshold."""
+        plan = plan_bid_changes(make_config(make_bid_config(500, "5.0")), ())
+        # 100h of runway at 9M sat/hour.
+        available = Sats(_BURN_RATE_SAT_PER_HOUR * 100)
+
+        result = check_balance(plan, available)
+
+        assert result.status == BalanceStatus.SUFFICIENT
+        assert result.required_sat == 100_000  # default amount
+        assert result.burn_rate.amount == Decimal(_BURN_RATE_SAT_PER_DAY)
+        assert result.runway == timedelta(hours=100)
+
+    def test_short_runway_is_low(self) -> None:
+        """Funds cover creates but runway is under the warning threshold."""
+        plan = plan_bid_changes(make_config(make_bid_config(500, "5.0")), ())
+        # 71h of runway (< 72h threshold).
+        available = Sats(_BURN_RATE_SAT_PER_HOUR * 71)
+
+        result = check_balance(plan, available)
+
+        assert result.status == BalanceStatus.LOW
+        assert result.runway == timedelta(hours=71)
+
+    def test_exactly_threshold_runway_is_sufficient(self) -> None:
+        """Runway exactly equal to the threshold is not flagged as LOW."""
+        plan = plan_bid_changes(make_config(make_bid_config(500, "5.0")), ())
+        available = Sats(_BURN_RATE_SAT_PER_HOUR * 72)
+
+        result = check_balance(plan, available)
+
+        assert result.status == BalanceStatus.SUFFICIENT
+        assert result.runway == LOW_BALANCE_RUNWAY
+
+    def test_balance_below_required_is_insufficient(self) -> None:
+        """Balance smaller than the creates' amount_sat is INSUFFICIENT."""
+        plan = plan_bid_changes(make_config(make_bid_config(500, "5.0")), ())
+        # default_amount is 100_000; 50_000 is not enough to fund the create.
+        result = check_balance(plan, Sats(50_000))
+
+        assert result.status == BalanceStatus.INSUFFICIENT
+        assert result.required_sat == 100_000
+        assert result.available_sat == 50_000
+
+    def test_insufficient_takes_precedence_over_low(self) -> None:
+        """INSUFFICIENT wins even when runway is also below threshold."""
+        plan = plan_bid_changes(
+            make_config(
+                make_bid_config(500, "5.0"),
+                make_bid_config(500, "5.0"),
+            ),
+            (),
+        )
+        # required = 2 * 100_000 = 200_000; not enough.
+        result = check_balance(plan, Sats(100_000))
+
+        assert result.status == BalanceStatus.INSUFFICIENT
+        assert result.required_sat == 200_000
+
+    def test_burn_rate_sums_across_creates(self) -> None:
+        """Burn rate is the sum over all planned creates."""
+        plan = plan_bid_changes(
+            make_config(
+                make_bid_config(500, "5.0"),
+                make_bid_config(500, "5.0"),
+            ),
+            (),
+        )
+        available = Sats(_BURN_RATE_SAT_PER_HOUR * 2 * 1000)
+
+        result = check_balance(plan, available)
+
+        assert result.burn_rate.amount == Decimal(_BURN_RATE_SAT_PER_DAY * 2)
+        assert result.required_sat == 200_000

--- a/tests/unit/test_braiins_client.py
+++ b/tests/unit/test_braiins_client.py
@@ -215,6 +215,108 @@ class TestGetMarketSettings:
         assert captured[0].headers["apikey"] == API_KEY
 
 
+class TestGetAccountBalance:
+    """Tests for BraiinsClient.get_account_balance parsing."""
+
+    def test_parses_single_account(self) -> None:
+        """A single-account response is parsed into AccountBalance."""
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(
+                200,
+                json={
+                    "accounts": [
+                        {
+                            "subaccount": "main",
+                            "currency": "BTC",
+                            "total_balance_sat": 1_500_000,
+                            "available_balance_sat": 1_200_000,
+                            "blocked_balance_sat": 300_000,
+                            "total_deposited_sat": 0,
+                            "total_withdrawn_sat": 0,
+                            "total_spot_spent_sat": 0,
+                            "total_spot_revenue_gross_sat": 0,
+                            "total_spot_revenue_net_sat": 0,
+                            "total_spent_spot_buy_fees_sat": 0,
+                            "total_spent_spot_sell_fees_sat": 0,
+                            "total_spent_fees_sat": 0,
+                            "has_pending_withdrawal": False,
+                        }
+                    ]
+                },
+            )
+
+        client = _make_client(httpx.MockTransport(handler))
+        balance = client.get_account_balance()
+
+        assert int(balance.available_sat) == 1_200_000
+        assert int(balance.blocked_sat) == 300_000
+        assert int(balance.total_sat) == 1_500_000
+        assert captured[0].method == "GET"
+        assert captured[0].url.path.endswith("/account/balance")
+        assert captured[0].headers["apikey"] == API_KEY
+
+    def test_empty_accounts_raises(self) -> None:
+        """Zero accounts in the response raises ValueError."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"accounts": []})
+
+        client = _make_client(httpx.MockTransport(handler))
+        with pytest.raises(ValueError, match="exactly one account"):
+            client.get_account_balance()
+
+    def test_multiple_accounts_raises(self) -> None:
+        """More than one account in the response raises ValueError."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "accounts": [
+                        {
+                            "subaccount": "a",
+                            "currency": "BTC",
+                            "total_balance_sat": 1,
+                            "available_balance_sat": 1,
+                            "blocked_balance_sat": 0,
+                            "total_deposited_sat": 0,
+                            "total_withdrawn_sat": 0,
+                            "total_spot_spent_sat": 0,
+                            "total_spot_revenue_gross_sat": 0,
+                            "total_spot_revenue_net_sat": 0,
+                            "total_spent_spot_buy_fees_sat": 0,
+                            "total_spent_spot_sell_fees_sat": 0,
+                            "total_spent_fees_sat": 0,
+                            "has_pending_withdrawal": False,
+                        },
+                        {
+                            "subaccount": "b",
+                            "currency": "BTC",
+                            "total_balance_sat": 2,
+                            "available_balance_sat": 2,
+                            "blocked_balance_sat": 0,
+                            "total_deposited_sat": 0,
+                            "total_withdrawn_sat": 0,
+                            "total_spot_spent_sat": 0,
+                            "total_spot_revenue_gross_sat": 0,
+                            "total_spot_revenue_net_sat": 0,
+                            "total_spent_spot_buy_fees_sat": 0,
+                            "total_spent_spot_sell_fees_sat": 0,
+                            "total_spent_fees_sat": 0,
+                            "has_pending_withdrawal": False,
+                        },
+                    ]
+                },
+            )
+
+        client = _make_client(httpx.MockTransport(handler))
+        with pytest.raises(ValueError, match="exactly one account"):
+            client.get_account_balance()
+
+
 class TestApiErrorParsing:
     """Tests for error response handling."""
 

--- a/tests/unit/test_formatting.py
+++ b/tests/unit/test_formatting.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 
 from hashbidder.bid_runner import SetBidsResult
 from hashbidder.client import BidStatus
+from hashbidder.domain.balance_check import BalanceCheck, BalanceStatus
 from hashbidder.domain.bid_planning import (
     CancelAction,
     CancelReason,
@@ -15,9 +16,12 @@ from hashbidder.domain.bid_planning import (
 )
 from hashbidder.domain.hashrate import Hashrate, HashratePrice, HashUnit
 from hashbidder.domain.sats import Sats
+from hashbidder.domain.sats_burn_rate import SatsBurnRate
 from hashbidder.domain.time_unit import TimeUnit
 from hashbidder.formatting import (
+    format_balance_check,
     format_plan,
+    format_set_bids_result,
     format_set_bids_target_result_verbose,
 )
 from hashbidder.target_hashrate import BidWithCooldown, CooldownInfo
@@ -274,6 +278,112 @@ class TestFormatPlan:
 
         assert "CANCEL B1:" in output
         assert "No active bids." in output
+
+
+def _make_balance_check(
+    status: BalanceStatus,
+    *,
+    required: int = 100_000,
+    available: int = 1_000_000_000,
+    burn_rate_sat_per_day: int = 216_000_000,
+    runway: timedelta = timedelta(hours=100),
+) -> BalanceCheck:
+    return BalanceCheck(
+        required_sat=Sats(required),
+        available_sat=Sats(available),
+        burn_rate=SatsBurnRate(Decimal(burn_rate_sat_per_day), timedelta(days=1)),
+        runway=runway,
+        status=status,
+    )
+
+
+class TestFormatBalanceCheck:
+    """Tests for format_balance_check."""
+
+    def test_sufficient(self) -> None:
+        """A sufficient balance renders status SUFFICIENT."""
+        output = format_balance_check(_make_balance_check(BalanceStatus.SUFFICIENT))
+        assert "=== Account Balance ===" in output
+        assert "Available:  1,000,000,000 sat" in output
+        assert "Required:   100,000 sat" in output
+        assert "9,000,000 sat/hour" in output
+        assert "Runway:     100.0h" in output
+        assert "Status:     SUFFICIENT" in output
+
+    def test_low(self) -> None:
+        """A LOW status mentions the runway threshold."""
+        output = format_balance_check(
+            _make_balance_check(BalanceStatus.LOW, runway=timedelta(hours=50))
+        )
+        assert "Runway:     50.0h" in output
+        assert "LOW" in output
+        assert "72h" in output
+
+    def test_insufficient(self) -> None:
+        """An INSUFFICIENT status notes the execution will be aborted."""
+        output = format_balance_check(
+            _make_balance_check(BalanceStatus.INSUFFICIENT, available=10)
+        )
+        assert "INSUFFICIENT" in output
+        assert "aborted" in output
+
+    def test_infinite_runway(self) -> None:
+        """A zero burn rate renders as infinite runway."""
+        check = BalanceCheck(
+            required_sat=Sats(0),
+            available_sat=Sats(500),
+            burn_rate=SatsBurnRate.zero(),
+            runway=timedelta.max,
+            status=BalanceStatus.SUFFICIENT,
+        )
+        output = format_balance_check(check)
+        assert "Runway:     \u221e" in output
+        assert "0 sat/hour" in output
+
+
+class TestFormatSetBidsResult:
+    """Tests for format_set_bids_result with balance-check wiring."""
+
+    def _plan_with_one_create(self) -> ReconciliationPlan:
+        return ReconciliationPlan(
+            edits=(),
+            creates=(
+                CreateAction(
+                    config=make_bid_config(500, "5.0"),
+                    amount=Sats(100_000),
+                    upstream=UPSTREAM,
+                ),
+            ),
+            cancels=(),
+            unchanged=(),
+        )
+
+    def test_dry_run_includes_balance_section(self) -> None:
+        """A dry run renders the balance section before the plan."""
+        result = SetBidsResult(
+            plan=self._plan_with_one_create(),
+            skipped_bids=(),
+            balance_check=_make_balance_check(BalanceStatus.SUFFICIENT),
+            execution=None,
+        )
+        output = format_set_bids_result(result)
+        assert "=== Account Balance ===" in output
+        assert "=== Changes ===" in output
+        assert output.index("=== Account Balance ===") < output.index("=== Changes ===")
+
+    def test_insufficient_aborted_run(self) -> None:
+        """An aborted run shows the balance section, abort notice, and plan."""
+        result = SetBidsResult(
+            plan=self._plan_with_one_create(),
+            skipped_bids=(),
+            balance_check=_make_balance_check(BalanceStatus.INSUFFICIENT, available=10),
+            execution=None,
+        )
+        output = format_set_bids_result(result)
+        assert "INSUFFICIENT" in output
+        assert "Execution aborted" in output
+        # The plan is still shown so the user sees what would have happened.
+        assert "=== Changes ===" in output
 
 
 class TestFormatTargetHashrateVerbose:

--- a/tests/unit/test_formatting.py
+++ b/tests/unit/test_formatting.py
@@ -25,7 +25,13 @@ from hashbidder.use_cases.set_bids_target import (
     SetBidsTargetResult,
     TargetHashrateInputs,
 )
-from tests.conftest import PH_DAY, UPSTREAM, make_bid_config, make_user_bid
+from tests.conftest import (
+    PH_DAY,
+    SUFFICIENT_BALANCE_CHECK,
+    UPSTREAM,
+    make_bid_config,
+    make_user_bid,
+)
 
 
 def _empty_plan() -> ReconciliationPlan:
@@ -288,7 +294,12 @@ class TestFormatTargetHashrateVerbose:
         plan = ReconciliationPlan(edits=(), creates=(), cancels=(), unchanged=())
         return SetBidsTargetResult(
             inputs=inputs,
-            set_bids_result=SetBidsResult(plan=plan, skipped_bids=(), execution=None),
+            set_bids_result=SetBidsResult(
+                plan=plan,
+                skipped_bids=(),
+                balance_check=SUFFICIENT_BALANCE_CHECK,
+                execution=None,
+            ),
         )
 
     def test_no_existing_bids(self) -> None:

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -1,0 +1,88 @@
+"""Tests for the reconcile orchestration (balance check + execution)."""
+
+from hashbidder.bid_runner import reconcile
+from hashbidder.client import AccountBalance
+from hashbidder.domain.balance_check import BalanceStatus
+from hashbidder.domain.sats import Sats
+from tests.conftest import (
+    UPSTREAM,
+    FakeClient,
+    make_bid_config,
+    make_config,
+)
+
+
+def _balance(available: int) -> AccountBalance:
+    return AccountBalance(
+        available_sat=Sats(available),
+        blocked_sat=Sats(0),
+        total_sat=Sats(available),
+    )
+
+
+class TestReconcileBalanceCheck:
+    """Tests covering the balance-check gate in reconcile."""
+
+    def test_dry_run_runs_balance_check(self) -> None:
+        """A dry run still surfaces a balance check result."""
+        client = FakeClient(
+            current_bids=(),
+            account_balance=_balance(10_000_000_000),
+        )
+        config = make_config(make_bid_config(500, "5.0"), upstream=UPSTREAM)
+
+        result = reconcile(client, config, dry_run=True)
+
+        assert result.execution is None
+        assert result.balance_check.status == BalanceStatus.SUFFICIENT
+
+    def test_insufficient_balance_aborts_execution(self) -> None:
+        """INSUFFICIENT balance short-circuits: no API mutations."""
+        client = FakeClient(
+            current_bids=(),
+            # default_amount in make_config is 100_000; give 50_000 to be short.
+            account_balance=_balance(50_000),
+        )
+        config = make_config(make_bid_config(500, "5.0"), upstream=UPSTREAM)
+
+        result = reconcile(client, config, dry_run=False)
+
+        assert result.execution is None
+        assert result.balance_check.status == BalanceStatus.INSUFFICIENT
+        # No mutations were issued against the API.
+        mutations = [
+            c for c in client.calls if c[0] in ("create_bid", "edit_bid", "cancel_bid")
+        ]
+        assert mutations == []
+
+    def test_low_balance_still_executes(self) -> None:
+        """LOW balance is a warning, not a block — execution proceeds."""
+        # Burn rate for 500 sat/PH/Day @ 5 PH/s is 9M sat/hour.
+        # 71 hours * 9M = 639M available → runway under 72h (LOW),
+        # but easily covers the 100_000 sat required.
+        client = FakeClient(
+            current_bids=(),
+            account_balance=_balance(9_000_000 * 71),
+        )
+        config = make_config(make_bid_config(500, "5.0"), upstream=UPSTREAM)
+
+        result = reconcile(client, config, dry_run=False)
+
+        assert result.balance_check.status == BalanceStatus.LOW
+        assert result.execution is not None
+        # One create was issued.
+        assert any(c[0] == "create_bid" for c in client.calls)
+
+    def test_sufficient_balance_executes_normally(self) -> None:
+        """A comfortable balance executes the plan as before."""
+        client = FakeClient(
+            current_bids=(),
+            account_balance=_balance(10_000_000_000),
+        )
+        config = make_config(make_bid_config(500, "5.0"), upstream=UPSTREAM)
+
+        result = reconcile(client, config, dry_run=False)
+
+        assert result.balance_check.status == BalanceStatus.SUFFICIENT
+        assert result.execution is not None
+        assert any(c[0] == "create_bid" for c in client.calls)

--- a/tests/unit/test_sats_burn_rate.py
+++ b/tests/unit/test_sats_burn_rate.py
@@ -1,0 +1,74 @@
+"""Tests for the SatsBurnRate primitive."""
+
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+
+from hashbidder.domain.sats import Sats
+from hashbidder.domain.sats_burn_rate import SatsBurnRate
+
+
+class TestSatsBurnRate:
+    """Tests for SatsBurnRate."""
+
+    def test_zero_is_zero(self) -> None:
+        """The zero constructor yields a zero-amount rate."""
+        rate = SatsBurnRate.zero()
+        assert rate.amount == Decimal(0)
+
+    def test_negative_amount_rejected(self) -> None:
+        """Negative amounts are rejected."""
+        with pytest.raises(ValueError, match="non-negative"):
+            SatsBurnRate(Decimal(-1), timedelta(days=1))
+
+    def test_non_positive_period_rejected(self) -> None:
+        """A zero-length period is rejected."""
+        with pytest.raises(ValueError, match="period"):
+            SatsBurnRate(Decimal(100), timedelta(0))
+
+    def test_to_converts_between_periods(self) -> None:
+        """Converting between periods scales the amount linearly."""
+        # 2400 sat/day = 100 sat/hour.
+        rate = SatsBurnRate(Decimal(2400), timedelta(days=1))
+        hourly = rate.to(timedelta(hours=1))
+        assert hourly.amount == Decimal(100)
+        assert hourly.period == timedelta(hours=1)
+
+    def test_to_roundtrip(self) -> None:
+        """Converting through another period and back is lossless."""
+        rate = SatsBurnRate(Decimal(2400), timedelta(days=1))
+        assert rate.to(timedelta(hours=1)).to(timedelta(days=1)).amount == Decimal(2400)
+
+    def test_addition_same_period(self) -> None:
+        """Rates with the same period sum by amount."""
+        a = SatsBurnRate(Decimal(100), timedelta(days=1))
+        b = SatsBurnRate(Decimal(250), timedelta(days=1))
+        total = a + b
+        assert total.amount == Decimal(350)
+        assert total.period == timedelta(days=1)
+
+    def test_addition_normalizes_periods(self) -> None:
+        """Rates with different periods are normalized before summing."""
+        # 24 sat/day + 1 sat/hour = 24 + 24 = 48 sat/day.
+        a = SatsBurnRate(Decimal(24), timedelta(days=1))
+        b = SatsBurnRate(Decimal(1), timedelta(hours=1))
+        total = a + b
+        assert total.amount == Decimal(48)
+        assert total.period == timedelta(days=1)
+
+    def test_runway_zero_rate_is_max(self) -> None:
+        """A zero rate yields timedelta.max runway."""
+        rate = SatsBurnRate.zero()
+        assert rate.runway(Sats(1_000_000)) == timedelta.max
+
+    def test_runway_simple(self) -> None:
+        """Runway at a known rate matches hand calculation."""
+        # 2400 sat/day = 100 sat/hour → 500 sat lasts 5 hours.
+        rate = SatsBurnRate(Decimal(2400), timedelta(days=1))
+        assert rate.runway(Sats(500)) == timedelta(hours=5)
+
+    def test_runway_zero_balance(self) -> None:
+        """A zero balance has zero runway against a non-zero rate."""
+        rate = SatsBurnRate(Decimal(2400), timedelta(days=1))
+        assert rate.runway(Sats(0)) == timedelta(0)


### PR DESCRIPTION
Adds a pre-execution balance check to set-bids: fetches /account/balance, aborts if creates can't be funded, warns under 72h runway, exits non-zero on abort. Closes #14.