### PR TITLE
Proper cooldown detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # PROJECT
 
 notes/
+improved_bids/
+example-target-hashrate.toml
 
 
 

--- a/hashbidder/client.py
+++ b/hashbidder/client.py
@@ -10,6 +10,7 @@ from urllib.parse import unquote
 
 import httpx
 
+from hashbidder.domain.bid_history import BidHistoryEntry
 from hashbidder.domain.hashrate import Hashrate, HashratePrice, HashUnit
 from hashbidder.domain.price_tick import PriceTick
 from hashbidder.domain.progress import Progress
@@ -24,6 +25,7 @@ __all__ = [
     "AccountBalance",
     "ApiError",
     "AskItem",
+    "BidHistoryEntry",
     "BidId",
     "BidItem",
     "BidStatus",
@@ -154,6 +156,10 @@ class HashpowerClient(Protocol):
         """Fetch the authenticated account's balance."""
         ...
 
+    def get_bid_detail(self, bid_id: BidId) -> tuple[BidHistoryEntry, ...]:
+        """Fetch a bid's history as a tuple of BidHistoryEntry."""
+        ...
+
 
 def _parse_user_bid(item: dict[str, Any]) -> UserBid:
     bid = item["bid"]
@@ -192,6 +198,7 @@ class BraiinsClient:
     _SPOT_ORDERBOOK_PATH = "/spot/orderbook"
     _SPOT_BID_CURRENT_PATH = "/spot/bid/current"
     _SPOT_BID_PATH = "/spot/bid"
+    _SPOT_BID_DETAIL_PATH = "/spot/bid/detail"
     _SPOT_SETTINGS_PATH = "/spot/settings"
     _ACCOUNT_BALANCE_PATH = "/account/balance"
 
@@ -456,3 +463,37 @@ class BraiinsClient:
         logger.debug("Response %s (%d bytes)", response.status_code, len(response.text))
         if not response.is_success:
             self._raise_api_error(response)
+
+    def get_bid_detail(self, bid_id: BidId) -> tuple[BidHistoryEntry, ...]:
+        """Fetch a bid's full history.
+
+        Returns:
+            The bid's history entries in the order the server provides them.
+
+        Raises:
+            ApiError: If the API returns a non-2xx response (e.g. 404 for
+                an unknown bid, 403 for a bid owned by another user).
+        """
+        url = f"{self._base_url}{self._SPOT_BID_DETAIL_PATH}/{bid_id}"
+        logger.debug("GET %s", url)
+        response = self._http.get(url, headers=self._auth_headers())
+        logger.debug("Response %s (%d bytes)", response.status_code, len(response.text))
+        if not response.is_success:
+            self._raise_api_error(response)
+        data: dict[str, Any] = json.loads(response.text, parse_float=Decimal)
+        history = data.get("history") or []
+        return tuple(
+            BidHistoryEntry(
+                timestamp=datetime.fromisoformat(item["timestamp"]),
+                price=HashratePrice(
+                    sats=Sats(int(item["price_sat"])),
+                    per=Hashrate(Decimal(1), self._API_HASH_UNIT, self._API_TIME_UNIT),
+                ),
+                speed_limit_ph=Hashrate(
+                    Decimal(item["speed_limit_ph"]),
+                    self._API_SPEED_HASH_UNIT,
+                    self._API_SPEED_TIME_UNIT,
+                ),
+            )
+            for item in history
+        )

--- a/hashbidder/client.py
+++ b/hashbidder/client.py
@@ -157,7 +157,7 @@ class HashpowerClient(Protocol):
         """Fetch the authenticated account's balance."""
         ...
 
-    def get_bid_detail(self, bid_id: BidId) -> BidHistory:
+    def get_bid_history(self, bid_id: BidId) -> BidHistory:
         """Fetch a bid's history as a BidHistory."""
         ...
 
@@ -465,7 +465,7 @@ class BraiinsClient:
         if not response.is_success:
             self._raise_api_error(response)
 
-    def get_bid_detail(self, bid_id: BidId) -> BidHistory:
+    def get_bid_history(self, bid_id: BidId) -> BidHistory:
         """Fetch a bid's full history.
 
         Returns:

--- a/hashbidder/client.py
+++ b/hashbidder/client.py
@@ -10,7 +10,7 @@ from urllib.parse import unquote
 
 import httpx
 
-from hashbidder.domain.bid_history import BidHistoryEntry
+from hashbidder.domain.bid_history import BidHistory, BidHistoryEntry
 from hashbidder.domain.hashrate import Hashrate, HashratePrice, HashUnit
 from hashbidder.domain.price_tick import PriceTick
 from hashbidder.domain.progress import Progress
@@ -25,6 +25,7 @@ __all__ = [
     "AccountBalance",
     "ApiError",
     "AskItem",
+    "BidHistory",
     "BidHistoryEntry",
     "BidId",
     "BidItem",
@@ -156,8 +157,8 @@ class HashpowerClient(Protocol):
         """Fetch the authenticated account's balance."""
         ...
 
-    def get_bid_detail(self, bid_id: BidId) -> tuple[BidHistoryEntry, ...]:
-        """Fetch a bid's history as a tuple of BidHistoryEntry."""
+    def get_bid_detail(self, bid_id: BidId) -> BidHistory:
+        """Fetch a bid's history as a BidHistory."""
         ...
 
 
@@ -464,11 +465,11 @@ class BraiinsClient:
         if not response.is_success:
             self._raise_api_error(response)
 
-    def get_bid_detail(self, bid_id: BidId) -> tuple[BidHistoryEntry, ...]:
+    def get_bid_detail(self, bid_id: BidId) -> BidHistory:
         """Fetch a bid's full history.
 
         Returns:
-            The bid's history entries in the order the server provides them.
+            A BidHistory with the bid's entries normalised newest-first.
 
         Raises:
             ApiError: If the API returns a non-2xx response (e.g. 404 for
@@ -482,7 +483,7 @@ class BraiinsClient:
             self._raise_api_error(response)
         data: dict[str, Any] = json.loads(response.text, parse_float=Decimal)
         history = data.get("history") or []
-        return tuple(
+        entries = tuple(
             BidHistoryEntry(
                 timestamp=datetime.fromisoformat(item["timestamp"]),
                 price=HashratePrice(
@@ -497,3 +498,4 @@ class BraiinsClient:
             )
             for item in history
         )
+        return BidHistory(entries=entries)

--- a/hashbidder/domain/bid_history.py
+++ b/hashbidder/domain/bid_history.py
@@ -1,7 +1,8 @@
-"""Bid history entry domain type."""
+"""Bid history domain types."""
 
 from dataclasses import dataclass
 from datetime import datetime
+from itertools import pairwise
 
 from hashbidder.domain.hashrate import Hashrate, HashratePrice
 
@@ -17,3 +18,43 @@ class BidHistoryEntry:
     timestamp: datetime
     price: HashratePrice
     speed_limit_ph: Hashrate
+
+
+@dataclass(frozen=True)
+class BidHistory:
+    """A bid's history, normalised newest-first at construction.
+
+    Sorting is done once here so every query method can walk adjacent
+    entries without re-sorting or trusting the server's order.
+    """
+
+    entries: tuple[BidHistoryEntry, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "entries",
+            tuple(sorted(self.entries, key=lambda e: e.timestamp, reverse=True)),
+        )
+
+    def last_price_decrease_at(self) -> datetime | None:
+        """Timestamp of the most recent strict price decrease, or None.
+
+        A decrease is a transition from an older entry to a newer entry
+        whose ``price.sats`` is strictly smaller.
+        """
+        for newer, older in pairwise(self.entries):
+            if newer.price.sats < older.price.sats:
+                return newer.timestamp
+        return None
+
+    def last_speed_decrease_at(self) -> datetime | None:
+        """Timestamp of the most recent strict speed decrease, or None.
+
+        A decrease is a transition from an older entry to a newer entry
+        whose ``speed_limit_ph`` is strictly smaller.
+        """
+        for newer, older in pairwise(self.entries):
+            if newer.speed_limit_ph < older.speed_limit_ph:
+                return newer.timestamp
+        return None

--- a/hashbidder/domain/bid_history.py
+++ b/hashbidder/domain/bid_history.py
@@ -1,0 +1,19 @@
+"""Bid history entry domain type."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from hashbidder.domain.hashrate import Hashrate, HashratePrice
+
+
+@dataclass(frozen=True)
+class BidHistoryEntry:
+    """A single point in a bid's per-field value history.
+
+    Captures the price and speed limit at a given moment so consumers can
+    walk adjacent entries to detect strictly-downward transitions.
+    """
+
+    timestamp: datetime
+    price: HashratePrice
+    speed_limit_ph: Hashrate

--- a/hashbidder/formatting.py
+++ b/hashbidder/formatting.py
@@ -27,6 +27,7 @@ from hashbidder.domain.sats import Sats
 from hashbidder.domain.time_unit import TimeUnit
 from hashbidder.hashvalue import HashvalueComponents
 from hashbidder.ocean_client import AccountStats
+from hashbidder.target_hashrate import BidWithCooldown
 from hashbidder.use_cases import SetBidsTargetResult
 
 
@@ -430,7 +431,7 @@ def _format_target_distribution_math(
     return "\n".join(lines)
 
 
-def _format_target_cooldowns(annotated: tuple) -> str:  # type: ignore[type-arg]
+def _format_target_cooldowns(annotated: tuple[BidWithCooldown, ...]) -> str:
     lines = ["=== Cooldown Status ==="]
     if not annotated:
         lines.append("  (no existing bids)")

--- a/hashbidder/target_hashrate.py
+++ b/hashbidder/target_hashrate.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 
 from hashbidder.client import MarketSettings, OrderBook, UserBid
 from hashbidder.domain.bid_config import BidConfig
+from hashbidder.domain.bid_history import BidHistory
 from hashbidder.domain.hashrate import Hashrate, HashratePrice, HashUnit
 from hashbidder.domain.price_tick import PriceTick
 from hashbidder.domain.time_unit import TimeUnit
@@ -71,7 +72,16 @@ def check_cooldowns(
     settings: MarketSettings,
     now: datetime,
 ) -> tuple[BidWithCooldown, ...]:
-    """Annotate each bid with its current price/speed cooldown status."""
+    """Tier-1 pre-filter: flag bids that may be in a decrease cooldown.
+
+    Derived only from ``UserBid.last_updated``, which is bumped by any user
+    update — including increases and no-op rewrites — so a True flag here
+    means "possibly cooling, consult history to find out", not "cooling".
+    A False flag is authoritative: a bid untouched for the full window
+    cannot be in a decrease cooldown.
+
+    Use `cooldown_from_history` for the authoritative per-field answer.
+    """
     return tuple(
         BidWithCooldown(
             bid=bid,
@@ -86,6 +96,63 @@ def check_cooldowns(
             ),
         )
         for bid in bids
+    )
+
+
+def is_price_guaranteed_free(
+    bid: UserBid, settings: MarketSettings, now: datetime
+) -> bool:
+    """True iff the bid's price is provably past its decrease window.
+
+    Derived from ``UserBid.last_updated``, which is bumped by any user
+    update — including increases and no-op rewrites. If the bid has not
+    been touched for at least the price decrease period, no price
+    decrease can be sitting inside that window.
+
+    A False answer is non-committal ("we can't tell from this alone")
+    and must be resolved by fetching the bid's history.
+    """
+    return now - bid.last_updated >= settings.min_bid_price_decrease_period
+
+
+def is_speed_guaranteed_free(
+    bid: UserBid, settings: MarketSettings, now: datetime
+) -> bool:
+    """True iff the bid's speed limit is provably past its decrease window.
+
+    Derived from ``UserBid.last_updated``, which is bumped by any user
+    update — including increases and no-op rewrites. If the bid has not
+    been touched for at least the speed decrease period, no speed
+    decrease can be sitting inside that window.
+
+    A False answer is non-committal ("we can't tell from this alone")
+    and must be resolved by fetching the bid's history.
+    """
+    return now - bid.last_updated >= settings.min_bid_speed_limit_decrease_period
+
+
+def cooldown_from_history(
+    history: BidHistory,
+    settings: MarketSettings,
+    now: datetime,
+) -> CooldownInfo:
+    """Authoritative per-field cooldown status derived from bid history.
+
+    Each flag is True iff the last decrease of that field occurred within
+    its own window in ``settings``. Missing timestamp (no decrease ever,
+    or none visible in history) → flag is False.
+    """
+    last_price = history.last_price_decrease_at()
+    last_speed = history.last_speed_decrease_at()
+    return CooldownInfo(
+        price_cooldown=(
+            last_price is not None
+            and now - last_price < settings.min_bid_price_decrease_period
+        ),
+        speed_cooldown=(
+            last_speed is not None
+            and now - last_speed < settings.min_bid_speed_limit_decrease_period
+        ),
     )
 
 

--- a/hashbidder/target_hashrate.py
+++ b/hashbidder/target_hashrate.py
@@ -67,38 +67,6 @@ class BidWithCooldown:
     cooldown: CooldownInfo
 
 
-def check_cooldowns(
-    bids: tuple[UserBid, ...],
-    settings: MarketSettings,
-    now: datetime,
-) -> tuple[BidWithCooldown, ...]:
-    """Tier-1 pre-filter: flag bids that may be in a decrease cooldown.
-
-    Derived only from ``UserBid.last_updated``, which is bumped by any user
-    update — including increases and no-op rewrites — so a True flag here
-    means "possibly cooling, consult history to find out", not "cooling".
-    A False flag is authoritative: a bid untouched for the full window
-    cannot be in a decrease cooldown.
-
-    Use `cooldown_from_history` for the authoritative per-field answer.
-    """
-    return tuple(
-        BidWithCooldown(
-            bid=bid,
-            cooldown=CooldownInfo(
-                price_cooldown=(
-                    now - bid.last_updated < settings.min_bid_price_decrease_period
-                ),
-                speed_cooldown=(
-                    now - bid.last_updated
-                    < settings.min_bid_speed_limit_decrease_period
-                ),
-            ),
-        )
-        for bid in bids
-    )
-
-
 def is_price_guaranteed_free(
     bid: UserBid, settings: MarketSettings, now: datetime
 ) -> bool:

--- a/hashbidder/use_cases/set_bids_target.py
+++ b/hashbidder/use_cases/set_bids_target.py
@@ -4,16 +4,19 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from hashbidder.bid_runner import SetBidsResult, reconcile
-from hashbidder.client import HashpowerClient
+from hashbidder.client import ApiError, HashpowerClient, MarketSettings, UserBid
 from hashbidder.config import SetBidsConfig, TargetHashrateConfig
 from hashbidder.domain.btc_address import BtcAddress
 from hashbidder.domain.hashrate import Hashrate, HashratePrice
 from hashbidder.ocean_client import OceanSource, OceanTimeWindow
 from hashbidder.target_hashrate import (
     BidWithCooldown,
-    check_cooldowns,
+    CooldownInfo,
     compute_needed_hashrate,
+    cooldown_from_history,
     find_market_price,
+    is_price_guaranteed_free,
+    is_speed_guaranteed_free,
     plan_with_cooldowns,
 )
 
@@ -46,6 +49,45 @@ def _ocean_24h(ocean: OceanSource, address: BtcAddress) -> Hashrate:
     raise ValueError("Ocean stats response did not include a 24h window")
 
 
+def resolve_cooldowns(
+    bids: tuple[UserBid, ...],
+    settings: MarketSettings,
+    now: datetime,
+    client: HashpowerClient,
+) -> tuple[BidWithCooldown, ...]:
+    """Per-bid cooldown annotation via a cheap tier-1 check, then tier-2 history.
+
+    Per bid, in order:
+
+    1. **Cheap check.** If the tier-1 predicates prove both fields past
+       their decrease windows (i.e. ``last_updated`` is old enough),
+       emit ``CooldownInfo(False, False)`` — no history fetch needed.
+    2. **History fetch.** Otherwise, call ``get_bid_detail`` and derive
+       the authoritative answer from the bid's history.
+    3. **Fetch failure fallback.** If the history fetch raises an
+       ``ApiError``, fall back to a per-field conservative estimate:
+       each flag is True unless its tier-1 predicate proves it free.
+    """
+    annotated: list[BidWithCooldown] = []
+    for bid in bids:
+        price_free = is_price_guaranteed_free(bid, settings, now)
+        speed_free = is_speed_guaranteed_free(bid, settings, now)
+        if price_free and speed_free:
+            cooldown = CooldownInfo(price_cooldown=False, speed_cooldown=False)
+        else:
+            try:
+                history = client.get_bid_detail(bid.id)
+            except ApiError:
+                cooldown = CooldownInfo(
+                    price_cooldown=not price_free,
+                    speed_cooldown=not speed_free,
+                )
+            else:
+                cooldown = cooldown_from_history(history, settings, now)
+        annotated.append(BidWithCooldown(bid=bid, cooldown=cooldown))
+    return tuple(annotated)
+
+
 def set_bids_target(
     client: HashpowerClient,
     ocean: OceanSource,
@@ -60,7 +102,10 @@ def set_bids_target(
         1. Read Ocean's 24h hashrate.
         2. Find the cheapest served bid in the order book and undercut it by 1 sat.
         3. Compute needed hashrate.
-        4. Check per-bid cooldowns from market settings against `now`.
+        4. Resolve per-bid cooldowns: tier-1 cheap predicates clear bids
+           that are provably not-in-cooldown with zero extra calls; tier-2
+           fetches /spot/bid/detail history for the rest and derives
+           authoritative per-field timestamps.
         5. Build a cooldown-aware SetBidsConfig and hand it to reconciliation.
 
     `now` defaults to the current UTC time; tests inject a fixed value.
@@ -75,7 +120,7 @@ def set_bids_target(
     needed = compute_needed_hashrate(config.target_hashrate, ocean_24h)
 
     current_bids = client.get_current_bids()
-    annotated = check_cooldowns(current_bids, settings, now)
+    annotated = resolve_cooldowns(current_bids, settings, now, client)
     bids = plan_with_cooldowns(
         desired_price=price,
         needed=needed,

--- a/hashbidder/use_cases/set_bids_target.py
+++ b/hashbidder/use_cases/set_bids_target.py
@@ -62,7 +62,7 @@ def resolve_cooldowns(
     1. **Cheap check.** If the tier-1 predicates prove both fields past
        their decrease windows (i.e. ``last_updated`` is old enough),
        emit ``CooldownInfo(False, False)`` — no history fetch needed.
-    2. **History fetch.** Otherwise, call ``get_bid_detail`` and derive
+    2. **History fetch.** Otherwise, call ``get_bid_history`` and derive
        the authoritative answer from the bid's history.
     3. **Fetch failure fallback.** If the history fetch raises an
        ``ApiError``, fall back to a per-field conservative estimate:
@@ -76,7 +76,7 @@ def resolve_cooldowns(
             cooldown = CooldownInfo(price_cooldown=False, speed_cooldown=False)
         else:
             try:
-                history = client.get_bid_detail(bid.id)
+                history = client.get_bid_history(bid.id)
             except ApiError:
                 cooldown = CooldownInfo(
                     price_cooldown=not price_free,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from hashbidder.client import (
     AccountBalance,
     ApiError,
+    BidHistoryEntry,
     BidId,
     BidStatus,
     ClOrderId,
@@ -126,6 +127,7 @@ class FakeClient:
         errors: dict[tuple[str, str], list[ApiError]] | None = None,
         market_settings: MarketSettings = DEFAULT_MARKET_SETTINGS,
         account_balance: AccountBalance = DEFAULT_ACCOUNT_BALANCE,
+        bid_histories: dict[BidId, tuple[BidHistoryEntry, ...]] | None = None,
     ) -> None:
         """Initialize with optional canned data and error injection."""
         self._orderbook = orderbook or OrderBook(bids=(), asks=())
@@ -134,6 +136,7 @@ class FakeClient:
         self._errors = errors or {}
         self._market_settings = market_settings
         self._account_balance = account_balance
+        self._bid_histories = dict(bid_histories or {})
         self.calls: list[tuple[str, ...]] = []
 
     def get_market_settings(self) -> MarketSettings:
@@ -219,6 +222,14 @@ class FakeClient:
                 del self._bids[i]
                 return
         raise ApiError(404, f"Bid {order_id} not found")
+
+    def get_bid_detail(self, bid_id: BidId) -> tuple[BidHistoryEntry, ...]:
+        """Return seeded history for a bid, or raise ApiError 404."""
+        self.calls.append(("get_bid_detail", bid_id))
+        self._maybe_raise("get_bid_detail", bid_id)
+        if bid_id not in self._bid_histories:
+            raise ApiError(404, f"Bid {bid_id} not found")
+        return self._bid_histories[bid_id]
 
 
 class FakeMempoolSource:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,10 +223,10 @@ class FakeClient:
                 return
         raise ApiError(404, f"Bid {order_id} not found")
 
-    def get_bid_detail(self, bid_id: BidId) -> BidHistory:
+    def get_bid_history(self, bid_id: BidId) -> BidHistory:
         """Return seeded history for a bid, or raise ApiError 404."""
-        self.calls.append(("get_bid_detail", bid_id))
-        self._maybe_raise("get_bid_detail", bid_id)
+        self.calls.append(("get_bid_history", bid_id))
+        self._maybe_raise("get_bid_history", bid_id)
         if bid_id not in self._bid_histories:
             raise ApiError(404, f"Bid {bid_id} not found")
         return self._bid_histories[bid_id]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from hashbidder.client import (
     AccountBalance,
     ApiError,
-    BidHistoryEntry,
+    BidHistory,
     BidId,
     BidStatus,
     ClOrderId,
@@ -127,7 +127,7 @@ class FakeClient:
         errors: dict[tuple[str, str], list[ApiError]] | None = None,
         market_settings: MarketSettings = DEFAULT_MARKET_SETTINGS,
         account_balance: AccountBalance = DEFAULT_ACCOUNT_BALANCE,
-        bid_histories: dict[BidId, tuple[BidHistoryEntry, ...]] | None = None,
+        bid_histories: dict[BidId, BidHistory] | None = None,
     ) -> None:
         """Initialize with optional canned data and error injection."""
         self._orderbook = orderbook or OrderBook(bids=(), asks=())
@@ -223,7 +223,7 @@ class FakeClient:
                 return
         raise ApiError(404, f"Bid {order_id} not found")
 
-    def get_bid_detail(self, bid_id: BidId) -> tuple[BidHistoryEntry, ...]:
+    def get_bid_detail(self, bid_id: BidId) -> BidHistory:
         """Return seeded history for a bid, or raise ApiError 404."""
         self.calls.append(("get_bid_detail", bid_id))
         self._maybe_raise("get_bid_detail", bid_id)

--- a/tests/unit/test_bid_history.py
+++ b/tests/unit/test_bid_history.py
@@ -1,0 +1,199 @@
+"""Tests for the BidHistory domain type."""
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from hashbidder.domain.bid_history import BidHistory, BidHistoryEntry
+from hashbidder.domain.hashrate import Hashrate, HashratePrice, HashUnit
+from hashbidder.domain.sats import Sats
+from hashbidder.domain.time_unit import TimeUnit
+
+EH_DAY = Hashrate(Decimal(1), HashUnit.EH, TimeUnit.DAY)
+T0 = datetime(2026, 4, 17, 8, 0, tzinfo=UTC)
+
+
+def _entry(t: datetime, price_sat: int, speed: str) -> BidHistoryEntry:
+    return BidHistoryEntry(
+        timestamp=t,
+        price=HashratePrice(sats=Sats(price_sat), per=EH_DAY),
+        speed_limit_ph=Hashrate(Decimal(speed), HashUnit.PH, TimeUnit.SECOND),
+    )
+
+
+class TestBidHistoryNormalisation:
+    """Tests for the newest-first sort invariant."""
+
+    def test_out_of_order_input_is_sorted(self) -> None:
+        """Entries given older-first are reordered to newest-first."""
+        older = _entry(T0, 500_000, "5")
+        newer = _entry(T0 + timedelta(minutes=1), 500_000, "5")
+        history = BidHistory(entries=(older, newer))
+        assert history.entries == (newer, older)
+
+    def test_shuffled_input_is_sorted(self) -> None:
+        """Arbitrarily-ordered input is normalised deterministically."""
+        a = _entry(T0, 500_000, "5")
+        b = _entry(T0 + timedelta(minutes=1), 500_000, "5")
+        c = _entry(T0 + timedelta(minutes=2), 500_000, "5")
+        history = BidHistory(entries=(b, a, c))
+        assert history.entries == (c, b, a)
+
+
+class TestLastPriceDecreaseAt:
+    """Tests for BidHistory.last_price_decrease_at."""
+
+    def test_empty_history(self) -> None:
+        """No entries → None."""
+        assert BidHistory(entries=()).last_price_decrease_at() is None
+
+    def test_single_entry(self) -> None:
+        """One entry has no predecessor → None."""
+        history = BidHistory(entries=(_entry(T0, 500_000, "5"),))
+        assert history.last_price_decrease_at() is None
+
+    def test_monotone_increasing(self) -> None:
+        """Price only rises → None."""
+        history = BidHistory(
+            entries=(
+                _entry(T0, 500_000, "5"),
+                _entry(T0 + timedelta(minutes=1), 510_000, "5"),
+                _entry(T0 + timedelta(minutes=2), 520_000, "5"),
+            )
+        )
+        assert history.last_price_decrease_at() is None
+
+    def test_single_decrease(self) -> None:
+        """One drop → its timestamp."""
+        t1 = T0 + timedelta(minutes=1)
+        history = BidHistory(
+            entries=(_entry(T0, 500_000, "5"), _entry(t1, 400_000, "5"))
+        )
+        assert history.last_price_decrease_at() == t1
+
+    def test_up_down_up_picks_middle_event(self) -> None:
+        """A decrease sandwiched between increases is still the 'last' one."""
+        t1 = T0 + timedelta(minutes=1)
+        t2 = T0 + timedelta(minutes=2)  # ← the decrease
+        t3 = T0 + timedelta(minutes=3)
+        history = BidHistory(
+            entries=(
+                _entry(T0, 500_000, "5"),
+                _entry(t1, 600_000, "5"),
+                _entry(t2, 450_000, "5"),
+                _entry(t3, 700_000, "5"),
+            )
+        )
+        assert history.last_price_decrease_at() == t2
+
+    def test_noop_entries_ignored(self) -> None:
+        """Equal-valued entries are not decreases; the real drop wins."""
+        t1 = T0 + timedelta(minutes=1)  # real decrease
+        t2 = T0 + timedelta(minutes=2)  # no-op
+        t3 = T0 + timedelta(minutes=3)  # no-op
+        history = BidHistory(
+            entries=(
+                _entry(T0, 500_000, "5"),
+                _entry(t1, 400_000, "5"),
+                _entry(t2, 400_000, "5"),
+                _entry(t3, 400_000, "5"),
+            )
+        )
+        assert history.last_price_decrease_at() == t1
+
+    def test_unaffected_by_speed_changes(self) -> None:
+        """Only price transitions are considered."""
+        t1 = T0 + timedelta(minutes=1)
+        history = BidHistory(
+            entries=(_entry(T0, 500_000, "10"), _entry(t1, 500_000, "5"))
+        )
+        assert history.last_price_decrease_at() is None
+
+
+class TestLastSpeedDecreaseAt:
+    """Tests for BidHistory.last_speed_decrease_at."""
+
+    def test_empty_history(self) -> None:
+        """No entries → None."""
+        assert BidHistory(entries=()).last_speed_decrease_at() is None
+
+    def test_single_entry(self) -> None:
+        """One entry has no predecessor → None."""
+        history = BidHistory(entries=(_entry(T0, 500_000, "5"),))
+        assert history.last_speed_decrease_at() is None
+
+    def test_monotone_increasing(self) -> None:
+        """Speed only rises → None."""
+        history = BidHistory(
+            entries=(
+                _entry(T0, 500_000, "5"),
+                _entry(T0 + timedelta(minutes=1), 500_000, "6"),
+                _entry(T0 + timedelta(minutes=2), 500_000, "7"),
+            )
+        )
+        assert history.last_speed_decrease_at() is None
+
+    def test_single_decrease(self) -> None:
+        """One drop → its timestamp."""
+        t1 = T0 + timedelta(minutes=1)
+        history = BidHistory(
+            entries=(_entry(T0, 500_000, "10"), _entry(t1, 500_000, "5"))
+        )
+        assert history.last_speed_decrease_at() == t1
+
+    def test_up_down_up_picks_middle_event(self) -> None:
+        """A decrease sandwiched between increases is still the 'last' one."""
+        t1 = T0 + timedelta(minutes=1)
+        t2 = T0 + timedelta(minutes=2)  # ← the decrease
+        t3 = T0 + timedelta(minutes=3)
+        history = BidHistory(
+            entries=(
+                _entry(T0, 500_000, "5"),
+                _entry(t1, 500_000, "10"),
+                _entry(t2, 500_000, "3"),
+                _entry(t3, 500_000, "15"),
+            )
+        )
+        assert history.last_speed_decrease_at() == t2
+
+    def test_noop_entries_ignored(self) -> None:
+        """Equal-valued entries are not decreases; the real drop wins."""
+        t1 = T0 + timedelta(minutes=1)  # real decrease
+        t2 = T0 + timedelta(minutes=2)  # no-op
+        t3 = T0 + timedelta(minutes=3)  # no-op
+        history = BidHistory(
+            entries=(
+                _entry(T0, 500_000, "10"),
+                _entry(t1, 500_000, "5"),
+                _entry(t2, 500_000, "5"),
+                _entry(t3, 500_000, "5"),
+            )
+        )
+        assert history.last_speed_decrease_at() == t1
+
+    def test_unaffected_by_price_changes(self) -> None:
+        """Only speed transitions are considered."""
+        t1 = T0 + timedelta(minutes=1)
+        history = BidHistory(
+            entries=(_entry(T0, 500_000, "5"), _entry(t1, 400_000, "5"))
+        )
+        assert history.last_speed_decrease_at() is None
+
+
+class TestBothFieldsTogether:
+    """Tests that confirm the two methods are independent."""
+
+    def test_distinct_decrease_timestamps(self) -> None:
+        """Price and speed decreases are reported independently."""
+        t1 = T0 + timedelta(minutes=1)  # price drops
+        t2 = T0 + timedelta(minutes=2)  # nothing
+        t3 = T0 + timedelta(minutes=3)  # speed drops
+        history = BidHistory(
+            entries=(
+                _entry(T0, 500_000, "10"),
+                _entry(t1, 400_000, "10"),
+                _entry(t2, 400_000, "10"),
+                _entry(t3, 400_000, "5"),
+            )
+        )
+        assert history.last_price_decrease_at() == t1
+        assert history.last_speed_decrease_at() == t3

--- a/tests/unit/test_braiins_client.py
+++ b/tests/unit/test_braiins_client.py
@@ -20,6 +20,8 @@ from hashbidder.domain.sats import Sats
 from hashbidder.domain.stratum_url import StratumUrl
 from hashbidder.domain.time_unit import TimeUnit
 
+EH_DAY = Hashrate(Decimal(1), HashUnit.EH, TimeUnit.DAY)
+
 API_KEY = "test-api-key"
 BASE_URL = httpx.URL("http://test-api")
 
@@ -315,6 +317,82 @@ class TestGetAccountBalance:
         client = _make_client(httpx.MockTransport(handler))
         with pytest.raises(ValueError, match="exactly one account"):
             client.get_account_balance()
+
+
+class TestGetBidDetail:
+    """Tests for BraiinsClient.get_bid_detail parsing."""
+
+    @staticmethod
+    def _detail_response_body() -> dict[str, object]:
+        return {
+            "history": [
+                {
+                    "timestamp": "2026-04-15T09:00:00+00:00",
+                    "speed_limit_ph": 10.0,
+                    "price_sat": 600_000,
+                    "amount": 100_000,
+                    "status": "BID_STATUS_ACTIVE",
+                    "remark": "",
+                    "updated_by": {},
+                },
+                {
+                    "timestamp": "2026-04-16T09:00:00+00:00",
+                    "speed_limit_ph": 8.0,
+                    "price_sat": 500_000,
+                    "amount": 100_000,
+                    "status": "BID_STATUS_ACTIVE",
+                    "remark": "",
+                    "updated_by": {},
+                },
+            ]
+        }
+
+    def test_parses_history_entries(self) -> None:
+        """Each history entry becomes a BidHistoryEntry with matching units."""
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json=self._detail_response_body())
+
+        client = _make_client(httpx.MockTransport(handler))
+        entries = client.get_bid_detail(BidId("B42"))
+
+        assert captured[0].method == "GET"
+        assert captured[0].url.path.endswith("/spot/bid/detail/B42")
+        assert captured[0].headers["apikey"] == API_KEY
+
+        assert len(entries) == 2
+        assert entries[0].timestamp == datetime(2026, 4, 15, 9, 0, tzinfo=UTC)
+        assert entries[0].price == HashratePrice(sats=Sats(600_000), per=EH_DAY)
+        assert entries[0].speed_limit_ph == Hashrate(
+            Decimal("10.0"), HashUnit.PH, TimeUnit.SECOND
+        )
+        assert entries[1].timestamp == datetime(2026, 4, 16, 9, 0, tzinfo=UTC)
+        assert entries[1].price == HashratePrice(sats=Sats(500_000), per=EH_DAY)
+        assert entries[1].speed_limit_ph == Hashrate(
+            Decimal("8.0"), HashUnit.PH, TimeUnit.SECOND
+        )
+
+    def test_empty_history(self) -> None:
+        """A response with no history entries yields an empty tuple."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"history": []})
+
+        client = _make_client(httpx.MockTransport(handler))
+        assert client.get_bid_detail(BidId("B42")) == ()
+
+    def test_404_raises_api_error(self) -> None:
+        """An unknown bid id surfaces as ApiError 404."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, text="Bid not found")
+
+        client = _make_client(httpx.MockTransport(handler))
+        with pytest.raises(ApiError) as exc_info:
+            client.get_bid_detail(BidId("B999"))
+        assert exc_info.value.status_code == 404
 
 
 class TestApiErrorParsing:

--- a/tests/unit/test_braiins_client.py
+++ b/tests/unit/test_braiins_client.py
@@ -348,7 +348,7 @@ class TestGetBidDetail:
         }
 
     def test_parses_history_entries(self) -> None:
-        """Each history entry becomes a BidHistoryEntry with matching units."""
+        """Each history item becomes a BidHistoryEntry, normalised newest-first."""
         captured: list[httpx.Request] = []
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -356,32 +356,33 @@ class TestGetBidDetail:
             return httpx.Response(200, json=self._detail_response_body())
 
         client = _make_client(httpx.MockTransport(handler))
-        entries = client.get_bid_detail(BidId("B42"))
+        history = client.get_bid_detail(BidId("B42"))
 
         assert captured[0].method == "GET"
         assert captured[0].url.path.endswith("/spot/bid/detail/B42")
         assert captured[0].headers["apikey"] == API_KEY
 
-        assert len(entries) == 2
-        assert entries[0].timestamp == datetime(2026, 4, 15, 9, 0, tzinfo=UTC)
-        assert entries[0].price == HashratePrice(sats=Sats(600_000), per=EH_DAY)
-        assert entries[0].speed_limit_ph == Hashrate(
-            Decimal("10.0"), HashUnit.PH, TimeUnit.SECOND
-        )
-        assert entries[1].timestamp == datetime(2026, 4, 16, 9, 0, tzinfo=UTC)
-        assert entries[1].price == HashratePrice(sats=Sats(500_000), per=EH_DAY)
-        assert entries[1].speed_limit_ph == Hashrate(
+        # Response is older-first; BidHistory sorts to newest-first.
+        assert len(history.entries) == 2
+        assert history.entries[0].timestamp == datetime(2026, 4, 16, 9, 0, tzinfo=UTC)
+        assert history.entries[0].price == HashratePrice(sats=Sats(500_000), per=EH_DAY)
+        assert history.entries[0].speed_limit_ph == Hashrate(
             Decimal("8.0"), HashUnit.PH, TimeUnit.SECOND
+        )
+        assert history.entries[1].timestamp == datetime(2026, 4, 15, 9, 0, tzinfo=UTC)
+        assert history.entries[1].price == HashratePrice(sats=Sats(600_000), per=EH_DAY)
+        assert history.entries[1].speed_limit_ph == Hashrate(
+            Decimal("10.0"), HashUnit.PH, TimeUnit.SECOND
         )
 
     def test_empty_history(self) -> None:
-        """A response with no history entries yields an empty tuple."""
+        """A response with no history entries yields an empty BidHistory."""
 
         def handler(_request: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json={"history": []})
 
         client = _make_client(httpx.MockTransport(handler))
-        assert client.get_bid_detail(BidId("B42")) == ()
+        assert client.get_bid_detail(BidId("B42")).entries == ()
 
     def test_404_raises_api_error(self) -> None:
         """An unknown bid id surfaces as ApiError 404."""

--- a/tests/unit/test_braiins_client.py
+++ b/tests/unit/test_braiins_client.py
@@ -319,8 +319,8 @@ class TestGetAccountBalance:
             client.get_account_balance()
 
 
-class TestGetBidDetail:
-    """Tests for BraiinsClient.get_bid_detail parsing."""
+class TestGetBidHistory:
+    """Tests for BraiinsClient.get_bid_history parsing."""
 
     @staticmethod
     def _detail_response_body() -> dict[str, object]:
@@ -356,7 +356,7 @@ class TestGetBidDetail:
             return httpx.Response(200, json=self._detail_response_body())
 
         client = _make_client(httpx.MockTransport(handler))
-        history = client.get_bid_detail(BidId("B42"))
+        history = client.get_bid_history(BidId("B42"))
 
         assert captured[0].method == "GET"
         assert captured[0].url.path.endswith("/spot/bid/detail/B42")
@@ -382,7 +382,7 @@ class TestGetBidDetail:
             return httpx.Response(200, json={"history": []})
 
         client = _make_client(httpx.MockTransport(handler))
-        assert client.get_bid_detail(BidId("B42")).entries == ()
+        assert client.get_bid_history(BidId("B42")).entries == ()
 
     def test_404_raises_api_error(self) -> None:
         """An unknown bid id surfaces as ApiError 404."""
@@ -392,7 +392,7 @@ class TestGetBidDetail:
 
         client = _make_client(httpx.MockTransport(handler))
         with pytest.raises(ApiError) as exc_info:
-            client.get_bid_detail(BidId("B999"))
+            client.get_bid_history(BidId("B999"))
         assert exc_info.value.status_code == 404
 
 

--- a/tests/unit/test_fake_client.py
+++ b/tests/unit/test_fake_client.py
@@ -1,10 +1,21 @@
 """Tests for the stateful FakeClient test double."""
 
+from datetime import UTC, datetime
+from decimal import Decimal
+
 import pytest
 
-from hashbidder.client import ApiError, BidId, BidStatus, ClOrderId
+from hashbidder.client import ApiError, BidHistoryEntry, BidId, BidStatus, ClOrderId
+from hashbidder.domain.hashrate import Hashrate, HashratePrice, HashUnit
 from hashbidder.domain.sats import Sats
-from tests.conftest import UPSTREAM, FakeClient, make_bid_config, make_user_bid
+from hashbidder.domain.time_unit import TimeUnit
+from tests.conftest import (
+    EH_DAY,
+    UPSTREAM,
+    FakeClient,
+    make_bid_config,
+    make_user_bid,
+)
 
 
 class TestFakeClientCancel:
@@ -109,3 +120,26 @@ class TestFakeClientErrorInjection:
         client.cancel_bid(BidId("B1"))
 
         assert client.calls == [("edit_bid", "B1"), ("cancel_bid", "B1")]
+
+
+class TestFakeClientGetBidDetail:
+    """Tests for FakeClient.get_bid_detail."""
+
+    def test_returns_seeded_history(self) -> None:
+        """Seeded history is returned for the matching bid id."""
+        history = (
+            BidHistoryEntry(
+                timestamp=datetime(2026, 4, 15, tzinfo=UTC),
+                price=HashratePrice(sats=Sats(500_000), per=EH_DAY),
+                speed_limit_ph=Hashrate(Decimal("5.0"), HashUnit.PH, TimeUnit.SECOND),
+            ),
+        )
+        client = FakeClient(bid_histories={BidId("B1"): history})
+
+        assert client.get_bid_detail(BidId("B1")) == history
+
+    def test_unknown_id_raises_404(self) -> None:
+        """An id with no seeded history raises ApiError 404."""
+        client = FakeClient()
+        with pytest.raises(ApiError, match="not found"):
+            client.get_bid_detail(BidId("B999"))

--- a/tests/unit/test_fake_client.py
+++ b/tests/unit/test_fake_client.py
@@ -5,7 +5,14 @@ from decimal import Decimal
 
 import pytest
 
-from hashbidder.client import ApiError, BidHistoryEntry, BidId, BidStatus, ClOrderId
+from hashbidder.client import (
+    ApiError,
+    BidHistory,
+    BidHistoryEntry,
+    BidId,
+    BidStatus,
+    ClOrderId,
+)
 from hashbidder.domain.hashrate import Hashrate, HashratePrice, HashUnit
 from hashbidder.domain.sats import Sats
 from hashbidder.domain.time_unit import TimeUnit
@@ -127,12 +134,16 @@ class TestFakeClientGetBidDetail:
 
     def test_returns_seeded_history(self) -> None:
         """Seeded history is returned for the matching bid id."""
-        history = (
-            BidHistoryEntry(
-                timestamp=datetime(2026, 4, 15, tzinfo=UTC),
-                price=HashratePrice(sats=Sats(500_000), per=EH_DAY),
-                speed_limit_ph=Hashrate(Decimal("5.0"), HashUnit.PH, TimeUnit.SECOND),
-            ),
+        history = BidHistory(
+            entries=(
+                BidHistoryEntry(
+                    timestamp=datetime(2026, 4, 15, tzinfo=UTC),
+                    price=HashratePrice(sats=Sats(500_000), per=EH_DAY),
+                    speed_limit_ph=Hashrate(
+                        Decimal("5.0"), HashUnit.PH, TimeUnit.SECOND
+                    ),
+                ),
+            )
         )
         client = FakeClient(bid_histories={BidId("B1"): history})
 

--- a/tests/unit/test_fake_client.py
+++ b/tests/unit/test_fake_client.py
@@ -129,8 +129,8 @@ class TestFakeClientErrorInjection:
         assert client.calls == [("edit_bid", "B1"), ("cancel_bid", "B1")]
 
 
-class TestFakeClientGetBidDetail:
-    """Tests for FakeClient.get_bid_detail."""
+class TestFakeClientGetBidHistory:
+    """Tests for FakeClient.get_bid_history."""
 
     def test_returns_seeded_history(self) -> None:
         """Seeded history is returned for the matching bid id."""
@@ -147,10 +147,10 @@ class TestFakeClientGetBidDetail:
         )
         client = FakeClient(bid_histories={BidId("B1"): history})
 
-        assert client.get_bid_detail(BidId("B1")) == history
+        assert client.get_bid_history(BidId("B1")) == history
 
     def test_unknown_id_raises_404(self) -> None:
         """An id with no seeded history raises ApiError 404."""
         client = FakeClient()
         with pytest.raises(ApiError, match="not found"):
-            client.get_bid_detail(BidId("B999"))
+            client.get_bid_history(BidId("B999"))

--- a/tests/unit/test_formatting.py
+++ b/tests/unit/test_formatting.py
@@ -425,34 +425,64 @@ class TestFormatTargetHashrateVerbose:
         assert "=== Cooldown Status ===" in output
         assert "(no existing bids)" in output
 
-    def test_mixed_cooldowns(self) -> None:
-        """Each cooldown combination renders a distinct status label."""
+    def _annotated_one(
+        self,
+        bid_id: str,
+        price_sats: int,
+        speed: str,
+        *,
+        price_cooldown: bool,
+        speed_cooldown: bool,
+    ) -> tuple[BidWithCooldown, ...]:
         now = datetime(2026, 4, 12, 12, 0, 0, tzinfo=UTC)
-        b_free = make_user_bid("B1", 700, "1.0", last_updated=now - timedelta(days=1))
-        b_price = make_user_bid("B2", 800, "2.0", last_updated=now)
-        b_speed = make_user_bid("B3", 900, "3.0", last_updated=now)
-        b_both = make_user_bid("B4", 950, "4.0", last_updated=now)
-        annotated = (
+        bid = make_user_bid(bid_id, price_sats, speed, last_updated=now)
+        return (
             BidWithCooldown(
-                bid=b_free,
-                cooldown=CooldownInfo(price_cooldown=False, speed_cooldown=False),
+                bid=bid,
+                cooldown=CooldownInfo(
+                    price_cooldown=price_cooldown,
+                    speed_cooldown=speed_cooldown,
+                ),
             ),
-            BidWithCooldown(
-                bid=b_price,
-                cooldown=CooldownInfo(price_cooldown=True, speed_cooldown=False),
-            ),
-            BidWithCooldown(
-                bid=b_speed,
-                cooldown=CooldownInfo(price_cooldown=False, speed_cooldown=True),
-            ),
-            BidWithCooldown(
-                bid=b_both,
-                cooldown=CooldownInfo(price_cooldown=True, speed_cooldown=True),
-            ),
+        )
+
+    def test_both_free_renders_free(self) -> None:
+        """price=False, speed=False → `→ free`."""
+        annotated = self._annotated_one(
+            "B1", 700, "1.0", price_cooldown=False, speed_cooldown=False
         )
         output = format_set_bids_target_result_verbose(self._result(annotated))
         assert "B1  price=700 sat/PH/Day  limit=1 PH/Second  → free" in output
-        assert "B2  price=800 sat/PH/Day  limit=2 PH/Second  → price locked" in output
-        assert "B3" in output
-        assert "→ speed locked (price free)" in output
-        assert "B4  price=950 sat/PH/Day  limit=4 PH/Second  → price+speed" in output
+
+    def test_price_locked_only(self) -> None:
+        """price=True, speed=False → `→ price locked (speed free)`."""
+        annotated = self._annotated_one(
+            "B2", 800, "2.0", price_cooldown=True, speed_cooldown=False
+        )
+        output = format_set_bids_target_result_verbose(self._result(annotated))
+        assert (
+            "B2  price=800 sat/PH/Day  limit=2 PH/Second  → price locked (speed free)"
+            in output
+        )
+
+    def test_speed_locked_only(self) -> None:
+        """price=False, speed=True → `→ speed locked (price free)`."""
+        annotated = self._annotated_one(
+            "B3", 900, "3.0", price_cooldown=False, speed_cooldown=True
+        )
+        output = format_set_bids_target_result_verbose(self._result(annotated))
+        assert (
+            "B3  price=900 sat/PH/Day  limit=3 PH/Second  → speed locked (price free)"
+            in output
+        )
+
+    def test_both_locked(self) -> None:
+        """price=True, speed=True → `→ price+speed locked`."""
+        annotated = self._annotated_one(
+            "B4", 950, "4.0", price_cooldown=True, speed_cooldown=True
+        )
+        output = format_set_bids_target_result_verbose(self._result(annotated))
+        assert (
+            "B4  price=950 sat/PH/Day  limit=4 PH/Second  → price+speed locked"
+            in output
+        )

--- a/tests/unit/test_target_hashrate.py
+++ b/tests/unit/test_target_hashrate.py
@@ -301,7 +301,7 @@ _SPLIT_SETTINGS = MarketSettings(
 class TestIsPriceGuaranteedFree:
     """Tests for is_price_guaranteed_free — tier-1 boolean for the price field."""
 
-    def test_quiescent_bid_is_free(self) -> None:
+    def test_not_in_cooldown_bid_is_free(self) -> None:
         """Untouched for longer than the price window → provably past cooldown."""
         bid = make_user_bid(
             "B1", 500, "5.0", last_updated=_NOW - timedelta(seconds=3600)
@@ -331,7 +331,7 @@ class TestIsPriceGuaranteedFree:
 class TestIsSpeedGuaranteedFree:
     """Tests for is_speed_guaranteed_free — tier-1 boolean for the speed field."""
 
-    def test_quiescent_bid_is_free(self) -> None:
+    def test_not_in_cooldown_bid_is_free(self) -> None:
         """Untouched for longer than the speed window → provably past cooldown."""
         bid = make_user_bid(
             "B1", 500, "5.0", last_updated=_NOW - timedelta(seconds=3600)

--- a/tests/unit/test_target_hashrate.py
+++ b/tests/unit/test_target_hashrate.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 import pytest
 
 from hashbidder.client import BidItem, MarketSettings, OrderBook
+from hashbidder.domain.bid_history import BidHistory, BidHistoryEntry
 from hashbidder.domain.hashrate import Hashrate, HashratePrice, HashUnit
 from hashbidder.domain.price_tick import PriceTick
 from hashbidder.domain.sats import Sats
@@ -15,8 +16,11 @@ from hashbidder.target_hashrate import (
     CooldownInfo,
     check_cooldowns,
     compute_needed_hashrate,
+    cooldown_from_history,
     distribute_bids,
     find_market_price,
+    is_price_guaranteed_free,
+    is_speed_guaranteed_free,
     plan_with_cooldowns,
 )
 from tests.conftest import make_user_bid
@@ -277,6 +281,158 @@ class TestCheckCooldowns:
         )
         (entry,) = check_cooldowns((bid,), settings, _NOW)
         assert entry.cooldown == CooldownInfo(price_cooldown=True, speed_cooldown=False)
+
+
+def _history_entry(t: datetime, price_sat: int, speed: str) -> BidHistoryEntry:
+    return BidHistoryEntry(
+        timestamp=t,
+        price=HashratePrice(sats=Sats(price_sat), per=EH_DAY),
+        speed_limit_ph=_ph_s(speed),
+    )
+
+
+_SPLIT_SETTINGS = MarketSettings(
+    min_bid_price_decrease_period=timedelta(seconds=600),
+    min_bid_speed_limit_decrease_period=timedelta(seconds=60),
+    price_tick=_TICK,
+)
+
+
+class TestIsPriceGuaranteedFree:
+    """Tests for is_price_guaranteed_free — tier-1 boolean for the price field."""
+
+    def test_quiescent_bid_is_free(self) -> None:
+        """Untouched for longer than the price window → provably past cooldown."""
+        bid = make_user_bid(
+            "B1", 500, "5.0", last_updated=_NOW - timedelta(seconds=3600)
+        )
+        assert is_price_guaranteed_free(bid, _SETTINGS, _NOW) is True
+
+    def test_recently_touched_bid_is_not_free(self) -> None:
+        """Touched within the price window → non-committal (could be cooling)."""
+        bid = make_user_bid("B1", 500, "5.0", last_updated=_NOW - timedelta(seconds=10))
+        assert is_price_guaranteed_free(bid, _SETTINGS, _NOW) is False
+
+    def test_uses_only_the_price_window(self) -> None:
+        """Past the speed window but inside the price window → not free."""
+        bid = make_user_bid(
+            "B1", 500, "5.0", last_updated=_NOW - timedelta(seconds=120)
+        )
+        assert is_price_guaranteed_free(bid, _SPLIT_SETTINGS, _NOW) is False
+
+    def test_exact_boundary_is_free(self) -> None:
+        """At exactly the price-window boundary the predicate clears the bid."""
+        bid = make_user_bid(
+            "B1", 500, "5.0", last_updated=_NOW - timedelta(seconds=600)
+        )
+        assert is_price_guaranteed_free(bid, _SETTINGS, _NOW) is True
+
+
+class TestIsSpeedGuaranteedFree:
+    """Tests for is_speed_guaranteed_free — tier-1 boolean for the speed field."""
+
+    def test_quiescent_bid_is_free(self) -> None:
+        """Untouched for longer than the speed window → provably past cooldown."""
+        bid = make_user_bid(
+            "B1", 500, "5.0", last_updated=_NOW - timedelta(seconds=3600)
+        )
+        assert is_speed_guaranteed_free(bid, _SETTINGS, _NOW) is True
+
+    def test_recently_touched_bid_is_not_free(self) -> None:
+        """Touched within the speed window → non-committal (could be cooling)."""
+        bid = make_user_bid("B1", 500, "5.0", last_updated=_NOW - timedelta(seconds=10))
+        assert is_speed_guaranteed_free(bid, _SETTINGS, _NOW) is False
+
+    def test_independent_of_price_window(self) -> None:
+        """Past speed window but inside price window → speed is free, price isn't."""
+        bid = make_user_bid(
+            "B1", 500, "5.0", last_updated=_NOW - timedelta(seconds=120)
+        )
+        assert is_speed_guaranteed_free(bid, _SPLIT_SETTINGS, _NOW) is True
+        assert is_price_guaranteed_free(bid, _SPLIT_SETTINGS, _NOW) is False
+
+    def test_exact_boundary_is_free(self) -> None:
+        """At exactly the speed-window boundary the predicate clears the bid."""
+        bid = make_user_bid("B1", 500, "5.0", last_updated=_NOW - timedelta(seconds=60))
+        assert is_speed_guaranteed_free(bid, _SPLIT_SETTINGS, _NOW) is True
+
+
+class TestCooldownFromHistory:
+    """Tests for cooldown_from_history — the authoritative per-field answer."""
+
+    def test_recent_price_decrease_sets_only_price_flag(self) -> None:
+        """Only price dropped in window → price_cooldown=True, speed_cooldown=False."""
+        history = BidHistory(
+            entries=(
+                _history_entry(_NOW - timedelta(seconds=3600), 500_000, "5"),
+                _history_entry(_NOW - timedelta(seconds=60), 400_000, "5"),
+            )
+        )
+        assert cooldown_from_history(history, _SETTINGS, _NOW) == CooldownInfo(
+            price_cooldown=True, speed_cooldown=False
+        )
+
+    def test_recent_speed_decrease_sets_only_speed_flag(self) -> None:
+        """Only speed dropped in window → price_cooldown=False, speed_cooldown=True."""
+        history = BidHistory(
+            entries=(
+                _history_entry(_NOW - timedelta(seconds=3600), 500_000, "10"),
+                _history_entry(_NOW - timedelta(seconds=60), 500_000, "5"),
+            )
+        )
+        assert cooldown_from_history(history, _SETTINGS, _NOW) == CooldownInfo(
+            price_cooldown=False, speed_cooldown=True
+        )
+
+    def test_stale_decrease_outside_window_is_ignored(self) -> None:
+        """Per-field windows: only the decrease inside its own window locks."""
+        settings = MarketSettings(
+            min_bid_price_decrease_period=timedelta(seconds=600),
+            min_bid_speed_limit_decrease_period=timedelta(seconds=60),
+            price_tick=_TICK,
+        )
+        # Price drop at -120s: inside price window (600s), outside speed window (60s).
+        # Speed drop at -30s: inside both windows.
+        history = BidHistory(
+            entries=(
+                _history_entry(_NOW - timedelta(seconds=3600), 500_000, "10"),
+                _history_entry(_NOW - timedelta(seconds=120), 400_000, "10"),
+                _history_entry(_NOW - timedelta(seconds=30), 400_000, "5"),
+            )
+        )
+        assert cooldown_from_history(history, settings, _NOW) == CooldownInfo(
+            price_cooldown=True, speed_cooldown=True
+        )
+
+        # Now push the price drop outside the price window (>600s ago).
+        stale_history = BidHistory(
+            entries=(
+                _history_entry(_NOW - timedelta(seconds=3600), 500_000, "10"),
+                _history_entry(_NOW - timedelta(seconds=1000), 400_000, "10"),
+                _history_entry(_NOW - timedelta(seconds=30), 400_000, "5"),
+            )
+        )
+        assert cooldown_from_history(stale_history, settings, _NOW) == CooldownInfo(
+            price_cooldown=False, speed_cooldown=True
+        )
+
+    def test_recent_increase_only_yields_both_false(self) -> None:
+        """Non-decrease edits do not set either flag — the 09:52 false-positive case."""
+        history = BidHistory(
+            entries=(
+                _history_entry(_NOW - timedelta(seconds=3600), 400_000, "5"),
+                _history_entry(_NOW - timedelta(seconds=60), 500_000, "5"),
+            )
+        )
+        assert cooldown_from_history(history, _SETTINGS, _NOW) == CooldownInfo(
+            price_cooldown=False, speed_cooldown=False
+        )
+
+    def test_empty_history_yields_both_false(self) -> None:
+        """A brand-new bid (empty history) has no decrease events → free."""
+        assert cooldown_from_history(
+            BidHistory(entries=()), _SETTINGS, _NOW
+        ) == CooldownInfo(price_cooldown=False, speed_cooldown=False)
 
 
 class TestPlanWithCooldowns:

--- a/tests/unit/test_target_hashrate.py
+++ b/tests/unit/test_target_hashrate.py
@@ -14,7 +14,6 @@ from hashbidder.domain.time_unit import TimeUnit
 from hashbidder.target_hashrate import (
     BidWithCooldown,
     CooldownInfo,
-    check_cooldowns,
     compute_needed_hashrate,
     cooldown_from_history,
     distribute_bids,
@@ -247,40 +246,6 @@ def _annotated(bid: object, price_cd: bool, speed_cd: bool) -> BidWithCooldown:
         bid=bid,  # type: ignore[arg-type]
         cooldown=CooldownInfo(price_cooldown=price_cd, speed_cooldown=speed_cd),
     )
-
-
-class TestCheckCooldowns:
-    """Tests for check_cooldowns."""
-
-    def test_recent_bid_in_both_cooldowns(self) -> None:
-        """A bid updated 10s ago is in both cooldown windows."""
-        bid = make_user_bid("B1", 500, "5.0", last_updated=_NOW - timedelta(seconds=10))
-        (entry,) = check_cooldowns((bid,), _SETTINGS, _NOW)
-        assert entry.bid is bid
-        assert entry.cooldown == CooldownInfo(price_cooldown=True, speed_cooldown=True)
-
-    def test_old_bid_in_neither_cooldown(self) -> None:
-        """A bid updated well past both cooldown windows is free."""
-        bid = make_user_bid(
-            "B1", 500, "5.0", last_updated=_NOW - timedelta(seconds=3600)
-        )
-        (entry,) = check_cooldowns((bid,), _SETTINGS, _NOW)
-        assert entry.cooldown == CooldownInfo(
-            price_cooldown=False, speed_cooldown=False
-        )
-
-    def test_distinct_windows(self) -> None:
-        """Different periods can leave one cooldown active and the other not."""
-        settings = MarketSettings(
-            min_bid_price_decrease_period=timedelta(seconds=600),
-            min_bid_speed_limit_decrease_period=timedelta(seconds=60),
-            price_tick=_TICK,
-        )
-        bid = make_user_bid(
-            "B1", 500, "5.0", last_updated=_NOW - timedelta(seconds=120)
-        )
-        (entry,) = check_cooldowns((bid,), settings, _NOW)
-        assert entry.cooldown == CooldownInfo(price_cooldown=True, speed_cooldown=False)
 
 
 def _history_entry(t: datetime, price_sat: int, speed: str) -> BidHistoryEntry:

--- a/tests/unit/test_use_cases_set_bids_target.py
+++ b/tests/unit/test_use_cases_set_bids_target.py
@@ -5,7 +5,15 @@ from decimal import Decimal
 
 import pytest
 
-from hashbidder.client import BidItem, MarketSettings, OrderBook
+from hashbidder.client import (
+    ApiError,
+    BidHistory,
+    BidHistoryEntry,
+    BidId,
+    BidItem,
+    MarketSettings,
+    OrderBook,
+)
 from hashbidder.config import TargetHashrateConfig
 from hashbidder.domain.btc_address import BtcAddress
 from hashbidder.domain.hashrate import Hashrate, HashratePrice, HashUnit
@@ -263,3 +271,127 @@ class TestSetBidsTarget:
 
         with pytest.raises(ValueError, match="24h window"):
             set_bids_target(client, ocean, ADDRESS, _config("10"), dry_run=True)
+
+
+_DETAIL_SETTINGS = MarketSettings(
+    min_bid_price_decrease_period=timedelta(seconds=600),
+    min_bid_speed_limit_decrease_period=timedelta(seconds=600),
+    price_tick=PriceTick(sats=Sats(1000)),
+)
+
+
+def _history(entries: tuple[BidHistoryEntry, ...]) -> BidHistory:
+    return BidHistory(entries=entries)
+
+
+def _entry(t: datetime, price_sat_per_eh_day: int, speed: str) -> BidHistoryEntry:
+    return BidHistoryEntry(
+        timestamp=t,
+        price=HashratePrice(sats=Sats(price_sat_per_eh_day), per=EH_DAY),
+        speed_limit_ph=_ph_s(speed),
+    )
+
+
+def _detail_call_count(client: FakeClient) -> int:
+    return sum(1 for call in client.calls if call[0] == "get_bid_detail")
+
+
+class TestHistoryFetchWiring:
+    """Tests for the tier-1 / tier-2 wiring inside set_bids_target."""
+
+    def test_not_in_cooldown_bids_incur_zero_history_fetches(self) -> None:
+        """All bids past both decrease windows → no /spot/bid/detail calls."""
+        now = datetime(2026, 4, 12, 12, 0, 0, tzinfo=UTC)
+        old = now - timedelta(seconds=3600)
+        bids = (
+            make_user_bid("B1", 600, "2.0", last_updated=old),
+            make_user_bid("B2", 700, "3.0", last_updated=old),
+        )
+        client = FakeClient(
+            orderbook=_orderbook(served_price_sat=500_000),
+            current_bids=bids,
+            market_settings=_DETAIL_SETTINGS,
+        )
+        ocean = FakeOceanSource(account_stats=_account_stats("5"))
+
+        set_bids_target(client, ocean, ADDRESS, _config("10"), dry_run=True, now=now)
+
+        assert _detail_call_count(client) == 0
+
+    def test_recent_increase_only_history_clears_both_flags(self) -> None:
+        """Tier-1 ambiguous + history shows only an increase → bid is free."""
+        now = datetime(2026, 4, 12, 12, 0, 0, tzinfo=UTC)
+        bid = make_user_bid("B1", 501, "3.0", last_updated=now - timedelta(seconds=30))
+        # Price and speed strictly increased — nothing to cool for.
+        history = _history(
+            (
+                _entry(now - timedelta(seconds=3600), 400_000, "2"),
+                _entry(now - timedelta(seconds=60), 501_000, "3"),
+            )
+        )
+        client = FakeClient(
+            orderbook=_orderbook(served_price_sat=500_000),
+            current_bids=(bid,),
+            market_settings=_DETAIL_SETTINGS,
+            bid_histories={BidId("B1"): history},
+        )
+        ocean = FakeOceanSource(account_stats=_account_stats("5"))
+
+        result = set_bids_target(
+            client, ocean, ADDRESS, _config("10"), dry_run=True, now=now
+        )
+
+        assert _detail_call_count(client) == 1
+        (annotated,) = result.inputs.annotated_bids
+        assert annotated.cooldown.price_cooldown is False
+        assert annotated.cooldown.speed_cooldown is False
+
+    def test_recent_speed_decrease_sets_speed_cooldown_only(self) -> None:
+        """Tier-1 ambiguous + history shows a speed decrease → speed locked only."""
+        now = datetime(2026, 4, 12, 12, 0, 0, tzinfo=UTC)
+        bid = make_user_bid("B1", 501, "3.0", last_updated=now - timedelta(seconds=30))
+        history = _history(
+            (
+                _entry(now - timedelta(seconds=3600), 501_000, "6"),
+                _entry(now - timedelta(seconds=60), 501_000, "3"),
+            )
+        )
+        client = FakeClient(
+            orderbook=_orderbook(served_price_sat=500_000),
+            current_bids=(bid,),
+            market_settings=_DETAIL_SETTINGS,
+            bid_histories={BidId("B1"): history},
+        )
+        ocean = FakeOceanSource(account_stats=_account_stats("5"))
+
+        result = set_bids_target(
+            client, ocean, ADDRESS, _config("10"), dry_run=True, now=now
+        )
+
+        assert _detail_call_count(client) == 1
+        (annotated,) = result.inputs.annotated_bids
+        assert annotated.cooldown.speed_cooldown is True
+        assert annotated.cooldown.price_cooldown is False
+
+    def test_api_error_on_detail_falls_back_to_tier1(self) -> None:
+        """History fetch failure → conservative tier-1 flags, no crash."""
+        now = datetime(2026, 4, 12, 12, 0, 0, tzinfo=UTC)
+        bid = make_user_bid("B1", 501, "3.0", last_updated=now - timedelta(seconds=30))
+        client = FakeClient(
+            orderbook=_orderbook(served_price_sat=500_000),
+            current_bids=(bid,),
+            market_settings=_DETAIL_SETTINGS,
+            # No seeded history → get_bid_detail raises ApiError 404.
+            errors={("get_bid_detail", "B1"): [ApiError(500, "boom")]},
+        )
+        ocean = FakeOceanSource(account_stats=_account_stats("5"))
+
+        result = set_bids_target(
+            client, ocean, ADDRESS, _config("10"), dry_run=True, now=now
+        )
+
+        assert _detail_call_count(client) == 1
+        (annotated,) = result.inputs.annotated_bids
+        # Conservative fallback: bid is within both decrease windows → both True.
+        assert annotated.cooldown.price_cooldown is True
+        assert annotated.cooldown.speed_cooldown is True

--- a/tests/unit/test_use_cases_set_bids_target.py
+++ b/tests/unit/test_use_cases_set_bids_target.py
@@ -395,3 +395,68 @@ class TestHistoryFetchWiring:
         # Conservative fallback: bid is within both decrease windows → both True.
         assert annotated.cooldown.price_cooldown is True
         assert annotated.cooldown.speed_cooldown is True
+
+
+class TestRegressionProxyFalsePositive:
+    """Direct regression for the 2026-04-17 09:52:02 incident.
+
+    A recent non-decrease edit (price increase only) previously bumped
+    ``last_updated`` and the proxy-only check pinned both flags True,
+    leaving the bid frozen even though the server would have accepted a
+    decrease on either field. Tier-2 history must override the proxy and
+    free the bid so the planner can lower it.
+    """
+
+    def test_recent_price_increase_only_does_not_pin_bid(self) -> None:
+        """Proxy flags both True; history shows only a price rise → bid is free."""
+        now = datetime(2026, 4, 17, 9, 52, 2, tzinfo=UTC)
+        # last_updated = 2 minutes ago → well inside both 600s decrease windows.
+        bid = make_user_bid(
+            "B86609956915618911",
+            900,
+            "4.0",
+            last_updated=now - timedelta(seconds=120),
+        )
+        # Only a price increase (800_000 → 900_000 sat/EH/Day) within the window;
+        # speed unchanged. No decrease of either field.
+        history = _history(
+            (
+                _entry(now - timedelta(seconds=3600), 800_000, "4"),
+                _entry(now - timedelta(seconds=120), 900_000, "4"),
+            )
+        )
+        client = FakeClient(
+            orderbook=_orderbook(served_price_sat=500_000),
+            current_bids=(bid,),
+            market_settings=_DETAIL_SETTINGS,
+            bid_histories={BidId("B86609956915618911"): history},
+        )
+        ocean = FakeOceanSource(account_stats=_account_stats("5"))
+
+        result = set_bids_target(
+            client, ocean, ADDRESS, _config("10"), dry_run=True, now=now
+        )
+
+        # Tier-2 consulted once and cleared both flags.
+        assert _detail_call_count(client) == 1
+        (annotated,) = result.inputs.annotated_bids
+        assert annotated.cooldown.price_cooldown is False
+        assert annotated.cooldown.speed_cooldown is False
+
+        # The bid is no longer pinned: planner treats it as a fresh slot and
+        # the reconciler edits it down to the market price and distributed speed.
+        # needed=15, 3 slots → 5 PH/s each at desired price 501_000.
+        plan = result.set_bids_result.plan
+        assert plan.unchanged == ()
+        assert len(plan.edits) == 1
+        edit = plan.edits[0]
+        assert edit.bid is bid
+        assert edit.price_changed
+        assert edit.new_price.sats == Sats(501_000)
+        assert edit.speed_limit_changed
+        assert edit.new_speed_limit_ph == _ph_s("5")
+        assert len(plan.creates) == 2
+        for create in plan.creates:
+            assert create.config.price.sats == Sats(501_000)
+            assert create.config.speed_limit == _ph_s("5")
+        assert plan.cancels == ()

--- a/tests/unit/test_use_cases_set_bids_target.py
+++ b/tests/unit/test_use_cases_set_bids_target.py
@@ -292,15 +292,15 @@ def _entry(t: datetime, price_sat_per_eh_day: int, speed: str) -> BidHistoryEntr
     )
 
 
-def _detail_call_count(client: FakeClient) -> int:
-    return sum(1 for call in client.calls if call[0] == "get_bid_detail")
+def _history_call_count(client: FakeClient) -> int:
+    return sum(1 for call in client.calls if call[0] == "get_bid_history")
 
 
 class TestHistoryFetchWiring:
     """Tests for the tier-1 / tier-2 wiring inside set_bids_target."""
 
     def test_not_in_cooldown_bids_incur_zero_history_fetches(self) -> None:
-        """All bids past both decrease windows → no /spot/bid/detail calls."""
+        """All bids past both decrease windows → no get_bid_history calls."""
         now = datetime(2026, 4, 12, 12, 0, 0, tzinfo=UTC)
         old = now - timedelta(seconds=3600)
         bids = (
@@ -316,7 +316,7 @@ class TestHistoryFetchWiring:
 
         set_bids_target(client, ocean, ADDRESS, _config("10"), dry_run=True, now=now)
 
-        assert _detail_call_count(client) == 0
+        assert _history_call_count(client) == 0
 
     def test_recent_increase_only_history_clears_both_flags(self) -> None:
         """Tier-1 ambiguous + history shows only an increase → bid is free."""
@@ -341,7 +341,7 @@ class TestHistoryFetchWiring:
             client, ocean, ADDRESS, _config("10"), dry_run=True, now=now
         )
 
-        assert _detail_call_count(client) == 1
+        assert _history_call_count(client) == 1
         (annotated,) = result.inputs.annotated_bids
         assert annotated.cooldown.price_cooldown is False
         assert annotated.cooldown.speed_cooldown is False
@@ -368,7 +368,7 @@ class TestHistoryFetchWiring:
             client, ocean, ADDRESS, _config("10"), dry_run=True, now=now
         )
 
-        assert _detail_call_count(client) == 1
+        assert _history_call_count(client) == 1
         (annotated,) = result.inputs.annotated_bids
         assert annotated.cooldown.speed_cooldown is True
         assert annotated.cooldown.price_cooldown is False
@@ -381,8 +381,8 @@ class TestHistoryFetchWiring:
             orderbook=_orderbook(served_price_sat=500_000),
             current_bids=(bid,),
             market_settings=_DETAIL_SETTINGS,
-            # No seeded history → get_bid_detail raises ApiError 404.
-            errors={("get_bid_detail", "B1"): [ApiError(500, "boom")]},
+            # No seeded history → get_bid_history raises ApiError 404.
+            errors={("get_bid_history", "B1"): [ApiError(500, "boom")]},
         )
         ocean = FakeOceanSource(account_stats=_account_stats("5"))
 
@@ -390,7 +390,7 @@ class TestHistoryFetchWiring:
             client, ocean, ADDRESS, _config("10"), dry_run=True, now=now
         )
 
-        assert _detail_call_count(client) == 1
+        assert _history_call_count(client) == 1
         (annotated,) = result.inputs.annotated_bids
         # Conservative fallback: bid is within both decrease windows → both True.
         assert annotated.cooldown.price_cooldown is True
@@ -438,7 +438,7 @@ class TestRegressionProxyFalsePositive:
         )
 
         # Tier-2 consulted once and cleared both flags.
-        assert _detail_call_count(client) == 1
+        assert _history_call_count(client) == 1
         (annotated,) = result.inputs.annotated_bids
         assert annotated.cooldown.price_cooldown is False
         assert annotated.cooldown.speed_cooldown is False


### PR DESCRIPTION
Replace the last_updated cooldown proxy with a two-tier check: cheap per-field predicates clear not-under-cooldown bids with zero extra calls; ambiguous bids get clarified by fetching /spot/bid/detail and derive per-field decrease timestamps from history. Fixes the the previous behaviour which was erroneous and overly simplistic.